### PR TITLE
enhancement: Publish TypeScript type definitions for SEO API responses

### DIFF
--- a/resources/js/types/analysis.d.ts
+++ b/resources/js/types/analysis.d.ts
@@ -18,7 +18,7 @@ export type AnalyzerName =
     | 'focus_keyword'
     | 'heading_structure'
     | 'image_alt'
-    | 'internal_link'
+    | 'internal_links'
     | 'keyword_density'
     | 'meta_length'
     | 'readability';

--- a/resources/js/types/analysis.d.ts
+++ b/resources/js/types/analysis.d.ts
@@ -1,0 +1,100 @@
+/**
+ * Analysis type definitions.
+ *
+ * TypeScript types for SEO analysis results matching the AnalysisResultDTO
+ * and AnalysisResultResource API response shapes.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.1.0
+ */
+
+/**
+ * Union of the 8 built-in analyzer names.
+ */
+export type AnalyzerName =
+    | 'content_length'
+    | 'focus_keyword'
+    | 'heading_structure'
+    | 'image_alt'
+    | 'internal_link'
+    | 'keyword_density'
+    | 'meta_length'
+    | 'readability';
+
+/**
+ * Analysis grade based on overall score.
+ */
+export type AnalysisGrade = 'good' | 'ok' | 'poor';
+
+/**
+ * Analysis grade color for display.
+ */
+export type AnalysisGradeColor = 'green' | 'yellow' | 'red';
+
+/**
+ * Status of an individual analyzer check.
+ */
+export type AnalyzerStatus = 'pass' | 'warning' | 'fail';
+
+/**
+ * An individual issue or suggestion from analysis.
+ */
+export interface AnalysisFeedbackItem {
+    type: string;
+    message: string;
+}
+
+/**
+ * Result from a single analyzer.
+ */
+export interface AnalyzerResult {
+    score: number;
+    status: AnalyzerStatus;
+    recommendations: string[];
+}
+
+/**
+ * Core analysis result data matching AnalysisResultDTO properties.
+ */
+export interface AnalysisResult {
+    overall_score: number;
+    readability_score: number;
+    keyword_score: number;
+    meta_score: number;
+    content_score: number;
+    issues: AnalysisFeedbackItem[];
+    suggestions: AnalysisFeedbackItem[];
+    passed_checks: string[];
+    focus_keyword: string | null;
+    word_count: number;
+    analyzer_results: Partial<Record<AnalyzerName, AnalyzerResult>>;
+}
+
+/**
+ * Analysis API response from AnalysisResultResource.
+ *
+ * Includes computed grade and count fields.
+ */
+export interface AnalysisResultResponse {
+    overall_score: number;
+    grade: AnalysisGrade;
+    grade_label: string;
+    grade_color: AnalysisGradeColor;
+    scores: {
+        readability: number;
+        keyword: number;
+        meta: number;
+        content: number;
+    };
+    focus_keyword: string | null;
+    word_count: number;
+    issues: AnalysisFeedbackItem[];
+    issue_count: number;
+    suggestions: AnalysisFeedbackItem[];
+    suggestion_count: number;
+    passed_checks: string[];
+    passed_count: number;
+    analyzer_results: Partial<Record<AnalyzerName, AnalyzerResult>>;
+}

--- a/resources/js/types/components.d.ts
+++ b/resources/js/types/components.d.ts
@@ -1,0 +1,58 @@
+/**
+ * Component prop type definitions.
+ *
+ * TypeScript types for React/Vue SEO editor component props.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.1.0
+ */
+
+import type { SeoMetaResponse } from './seo-data';
+import type { RedirectMatchType, RedirectStatusCode } from './redirect';
+
+/**
+ * Props for the SEO editor component.
+ */
+export interface SeoEditorProps {
+    modelType: string;
+    modelId: number;
+    initialData?: SeoMetaResponse;
+}
+
+/**
+ * Sort direction for redirect manager.
+ */
+export type SortDirection = 'asc' | 'desc';
+
+/**
+ * Sortable fields for the redirect manager.
+ */
+export type RedirectSortField = 'from_path' | 'to_path' | 'status_code' | 'hits' | 'last_hit_at' | 'created_at';
+
+/**
+ * Filter options for the redirect manager.
+ */
+export interface RedirectFilterOptions {
+    status_code?: RedirectStatusCode;
+    match_type?: RedirectMatchType;
+    is_active?: boolean;
+    search?: string;
+}
+
+/**
+ * Sort options for the redirect manager.
+ */
+export interface RedirectSortOptions {
+    field: RedirectSortField;
+    direction: SortDirection;
+}
+
+/**
+ * Props for the redirect manager component.
+ */
+export interface RedirectManagerProps {
+    filters?: RedirectFilterOptions;
+    sort?: RedirectSortOptions;
+}

--- a/resources/js/types/hreflang.d.ts
+++ b/resources/js/types/hreflang.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Hreflang type definitions.
+ *
+ * TypeScript types for hreflang language/region URL mappings
+ * matching the HreflangResource API response shape.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.1.0
+ */
+
+/**
+ * A single hreflang entry mapping a language/region to a URL.
+ */
+export interface HreflangEntry {
+    hreflang: string;
+    href: string;
+}

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -1,0 +1,104 @@
+/**
+ * ArtisanPack UI SEO - TypeScript Type Definitions.
+ *
+ * Central export for all SEO package TypeScript types.
+ * Publish these types to your application with:
+ *
+ *   php artisan vendor:publish --tag=seo-types
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.1.0
+ */
+
+export type {
+    MetaTags,
+    MetaTagsResponse,
+} from './meta-tags';
+
+export type {
+    OpenGraphType,
+    OpenGraph,
+    OpenGraphResponse,
+} from './open-graph';
+
+export type {
+    TwitterCardType,
+    TwitterCard,
+    TwitterCardResponse,
+} from './twitter-card';
+
+export type {
+    HreflangEntry,
+} from './hreflang';
+
+export type {
+    SeoData,
+    AnalysisCacheSummary,
+    SeoMetaResponse,
+    SeoPreviewResponse,
+    SearchPreview,
+    OpenGraphPreview,
+    TwitterCardPreview,
+} from './seo-data';
+
+export type {
+    AnalyzerName,
+    AnalysisGrade,
+    AnalysisGradeColor,
+    AnalyzerStatus,
+    AnalysisFeedbackItem,
+    AnalyzerResult,
+    AnalysisResult,
+    AnalysisResultResponse,
+} from './analysis';
+
+export type {
+    SchemaType,
+    SchemaFieldType,
+    SchemaFieldDefinition,
+    ArticleSchemaConfig,
+    ProductSchemaConfig,
+    EventSchemaConfig,
+    FAQPageSchemaConfig,
+    BreadcrumbListSchemaConfig,
+    OrganizationSchemaConfig,
+    LocalBusinessSchemaConfig,
+    WebSiteSchemaConfig,
+    WebPageSchemaConfig,
+    ServiceSchemaConfig,
+    ReviewSchemaConfig,
+    AggregateRatingSchemaConfig,
+    SchemaConfig,
+    SchemaResponse,
+    PersonConfig,
+    OrganizationConfig,
+    OfferConfig,
+    AggregateRatingConfig,
+    ReviewItemConfig,
+    RatingConfig,
+    LocationConfig,
+    PostalAddressConfig,
+    GeoCoordinatesConfig,
+    OpeningHoursConfig,
+    FAQQuestionConfig,
+    BreadcrumbItemConfig,
+    ItemReviewedConfig,
+} from './schema';
+
+export type {
+    RedirectStatusCode,
+    RedirectMatchType,
+    Redirect,
+    RedirectTestResult,
+} from './redirect';
+
+export type {
+    SeoEditorProps,
+    SortDirection,
+    RedirectSortField,
+    RedirectFilterOptions,
+    RedirectSortOptions,
+    RedirectManagerProps,
+} from './components';

--- a/resources/js/types/meta-tags.d.ts
+++ b/resources/js/types/meta-tags.d.ts
@@ -1,0 +1,39 @@
+/**
+ * MetaTags type definitions.
+ *
+ * TypeScript types for HTML meta tag data matching the MetaTagsDTO
+ * and MetaTagsResource API response shapes.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.1.0
+ */
+
+/**
+ * Core meta tag data matching MetaTagsDTO properties.
+ */
+export interface MetaTags {
+    title: string;
+    description: string | null;
+    canonical: string;
+    robots: string;
+    additional_meta: Record<string, unknown>;
+}
+
+/**
+ * Meta tags API response from MetaTagsResource.
+ *
+ * Includes computed length and warning fields.
+ */
+export interface MetaTagsResponse {
+    title: string;
+    title_length: number;
+    title_warning: string | null;
+    description: string | null;
+    description_length: number;
+    description_warning: string | null;
+    canonical: string;
+    robots: string;
+    additional_meta: Record<string, unknown>;
+}

--- a/resources/js/types/open-graph.d.ts
+++ b/resources/js/types/open-graph.d.ts
@@ -1,0 +1,54 @@
+/**
+ * OpenGraph type definitions.
+ *
+ * TypeScript types for Open Graph meta tag data matching the OpenGraphDTO
+ * and OpenGraphResource API response shapes.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.1.0
+ */
+
+/**
+ * Valid Open Graph type values.
+ */
+export type OpenGraphType =
+    | 'website'
+    | 'article'
+    | 'book'
+    | 'profile'
+    | 'music.song'
+    | 'music.album'
+    | 'music.playlist'
+    | 'music.radio_station'
+    | 'video.movie'
+    | 'video.episode'
+    | 'video.tv_show'
+    | 'video.other';
+
+/**
+ * Open Graph data matching OpenGraphDTO properties.
+ */
+export interface OpenGraph {
+    title: string;
+    description: string | null;
+    image: string | null;
+    url: string;
+    type: OpenGraphType;
+    site_name: string;
+    locale: string;
+}
+
+/**
+ * Open Graph API response from OpenGraphResource.
+ */
+export interface OpenGraphResponse {
+    title: string;
+    description: string | null;
+    image: string | null;
+    url: string;
+    type: OpenGraphType;
+    site_name: string;
+    locale: string;
+}

--- a/resources/js/types/redirect.d.ts
+++ b/resources/js/types/redirect.d.ts
@@ -1,0 +1,50 @@
+/**
+ * Redirect type definitions.
+ *
+ * TypeScript types for URL redirect data matching the Redirect model
+ * and RedirectResource API response shapes.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.1.0
+ */
+
+/**
+ * Valid redirect HTTP status codes.
+ */
+export type RedirectStatusCode = 301 | 302 | 307 | 308;
+
+/**
+ * Valid redirect match types.
+ */
+export type RedirectMatchType = 'exact' | 'regex' | 'wildcard';
+
+/**
+ * Redirect API response from RedirectResource.
+ */
+export interface Redirect {
+    id: number;
+    from_path: string;
+    to_path: string;
+    status_code: RedirectStatusCode;
+    status_code_label: string;
+    match_type: RedirectMatchType;
+    match_type_label: string;
+    is_active: boolean;
+    is_permanent: boolean;
+    is_temporary: boolean;
+    hits: number;
+    last_hit_at: string | null;
+    notes: string | null;
+    created_at: string | null;
+    updated_at: string | null;
+}
+
+/**
+ * Result from testing a URL path against redirects.
+ */
+export interface RedirectTestResult {
+    matched: Redirect | null;
+    resolved_destination: string | null;
+}

--- a/resources/js/types/schema.d.ts
+++ b/resources/js/types/schema.d.ts
@@ -1,0 +1,335 @@
+/**
+ * Schema type definitions.
+ *
+ * TypeScript types for Schema.org configuration matching the SchemaFactory,
+ * schema builders, and SchemaResource API response shapes.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.1.0
+ */
+
+/**
+ * Union of the 13 built-in Schema.org type names.
+ */
+export type SchemaType =
+    | 'Organization'
+    | 'LocalBusiness'
+    | 'WebSite'
+    | 'WebPage'
+    | 'Article'
+    | 'BlogPosting'
+    | 'Product'
+    | 'Service'
+    | 'Event'
+    | 'FAQPage'
+    | 'BreadcrumbList'
+    | 'Review'
+    | 'AggregateRating';
+
+/**
+ * Schema field types for dynamic form rendering.
+ */
+export type SchemaFieldType = 'text' | 'textarea' | 'url' | 'number' | 'date' | 'datetime' | 'boolean' | 'array' | 'object' | 'select';
+
+/**
+ * Schema field definition for dynamic form rendering.
+ */
+export interface SchemaFieldDefinition {
+    name: string;
+    type: SchemaFieldType;
+    required: boolean;
+    description: string;
+}
+
+/**
+ * Article schema configuration fields.
+ */
+export interface ArticleSchemaConfig {
+    name?: string;
+    headline?: string;
+    description?: string;
+    url?: string;
+    image?: string;
+    author?: PersonConfig[];
+    publisher?: OrganizationConfig[];
+    datePublished?: string;
+    dateModified?: string;
+    dateCreated?: string;
+    articleBody?: string;
+    wordCount?: number;
+    keywords?: string;
+    articleSection?: string;
+    inLanguage?: string;
+}
+
+/**
+ * Product schema configuration fields.
+ */
+export interface ProductSchemaConfig {
+    name?: string;
+    description?: string;
+    image?: string;
+    url?: string;
+    sku?: string;
+    gtin?: string;
+    mpn?: string;
+    brand?: string;
+    offers?: OfferConfig[];
+    aggregateRating?: AggregateRatingConfig;
+    reviews?: ReviewItemConfig[];
+    category?: string;
+    color?: string;
+    material?: string;
+}
+
+/**
+ * Event schema configuration fields.
+ */
+export interface EventSchemaConfig {
+    name?: string;
+    description?: string;
+    url?: string;
+    image?: string;
+    startDate: string;
+    endDate?: string;
+    location?: LocationConfig;
+    virtualLocation?: string;
+    eventStatus?: string;
+    eventAttendanceMode?: string;
+    organizer?: OrganizationConfig[];
+    performer?: PersonConfig;
+    offers?: OfferConfig[];
+}
+
+/**
+ * FAQ page schema configuration fields.
+ */
+export interface FAQPageSchemaConfig {
+    name?: string;
+    description?: string;
+    url?: string;
+    questions: FAQQuestionConfig[];
+}
+
+/**
+ * BreadcrumbList schema configuration fields.
+ */
+export interface BreadcrumbListSchemaConfig {
+    items: BreadcrumbItemConfig[];
+}
+
+/**
+ * Organization schema configuration fields.
+ */
+export interface OrganizationSchemaConfig {
+    name?: string;
+    url?: string;
+    logo?: string;
+    email?: string;
+    phone?: string;
+    telephone?: string;
+    description?: string;
+    address?: PostalAddressConfig;
+    sameAs?: string[];
+}
+
+/**
+ * LocalBusiness schema configuration fields (extends Organization).
+ */
+export interface LocalBusinessSchemaConfig extends OrganizationSchemaConfig {
+    priceRange?: string;
+    openingHours?: OpeningHoursConfig[];
+    geo?: GeoCoordinatesConfig;
+    areaServed?: string;
+    paymentAccepted?: string;
+    currenciesAccepted?: string;
+}
+
+/**
+ * WebSite schema configuration fields.
+ */
+export interface WebSiteSchemaConfig {
+    name?: string;
+    url?: string;
+    description?: string;
+    publisher?: OrganizationConfig[];
+    searchUrl?: string;
+    alternateName?: string;
+    inLanguage?: string;
+}
+
+/**
+ * WebPage schema configuration fields.
+ */
+export interface WebPageSchemaConfig {
+    name?: string;
+    url?: string;
+    description?: string;
+    datePublished?: string;
+    dateModified?: string;
+    image?: string;
+    author?: PersonConfig[];
+    publisher?: OrganizationConfig[];
+    breadcrumb?: BreadcrumbItemConfig[];
+    isPartOf?: string;
+    inLanguage?: string;
+}
+
+/**
+ * Service schema configuration fields.
+ */
+export interface ServiceSchemaConfig {
+    name?: string;
+    description?: string;
+    url?: string;
+    image?: string;
+    provider?: OrganizationConfig[];
+    areaServed?: string;
+    serviceType?: string;
+    category?: string;
+    offers?: OfferConfig[];
+    aggregateRating?: AggregateRatingConfig;
+    brand?: string;
+}
+
+/**
+ * Review schema configuration fields.
+ */
+export interface ReviewSchemaConfig {
+    name?: string;
+    reviewBody?: string;
+    body?: string;
+    content?: string;
+    author: PersonConfig;
+    rating?: RatingConfig;
+    reviewRating?: RatingConfig;
+    datePublished?: string;
+    itemReviewed?: ItemReviewedConfig;
+    publisher?: OrganizationConfig[];
+}
+
+/**
+ * AggregateRating schema configuration fields.
+ */
+export interface AggregateRatingSchemaConfig {
+    ratingValue: number;
+    value?: number;
+    bestRating?: number;
+    worstRating?: number;
+    ratingCount: number;
+    count?: number;
+    reviewCount?: number;
+    itemReviewed?: ItemReviewedConfig;
+}
+
+/**
+ * Union of all schema configuration types.
+ */
+export type SchemaConfig =
+    | ArticleSchemaConfig
+    | ProductSchemaConfig
+    | EventSchemaConfig
+    | FAQPageSchemaConfig
+    | BreadcrumbListSchemaConfig
+    | OrganizationSchemaConfig
+    | LocalBusinessSchemaConfig
+    | WebSiteSchemaConfig
+    | WebPageSchemaConfig
+    | ServiceSchemaConfig
+    | ReviewSchemaConfig
+    | AggregateRatingSchemaConfig;
+
+/**
+ * Schema API response from SchemaResource.
+ */
+export interface SchemaResponse {
+    schema_type: SchemaType | null;
+    schema_markup: Record<string, unknown> | null;
+    generated: Record<string, unknown> | null;
+    available_types: SchemaType[];
+}
+
+/**
+ * Helper types used across schema configurations.
+ */
+
+export interface PersonConfig {
+    name: string;
+    url?: string;
+}
+
+export interface OrganizationConfig {
+    name: string;
+    url?: string;
+    logo?: string;
+}
+
+export interface OfferConfig {
+    price?: string | number;
+    priceCurrency?: string;
+    availability?: string;
+    url?: string;
+    validFrom?: string;
+}
+
+export interface AggregateRatingConfig {
+    ratingValue: number;
+    reviewCount?: number;
+    bestRating?: number;
+    worstRating?: number;
+}
+
+export interface ReviewItemConfig {
+    author: string;
+    reviewBody: string;
+    reviewRating?: RatingConfig;
+    datePublished?: string;
+}
+
+export interface RatingConfig {
+    ratingValue: number;
+    bestRating?: number;
+    worstRating?: number;
+}
+
+export interface LocationConfig {
+    name?: string;
+    address?: PostalAddressConfig;
+}
+
+export interface PostalAddressConfig {
+    streetAddress?: string;
+    addressLocality?: string;
+    addressRegion?: string;
+    postalCode?: string;
+    addressCountry?: string;
+}
+
+export interface GeoCoordinatesConfig {
+    latitude: number;
+    longitude: number;
+}
+
+export interface OpeningHoursConfig {
+    dayOfWeek: string;
+    opens: string;
+    closes: string;
+}
+
+export interface FAQQuestionConfig {
+    question: string;
+    answer: string;
+}
+
+export interface BreadcrumbItemConfig {
+    name: string;
+    url: string;
+}
+
+export interface ItemReviewedConfig {
+    name: string;
+    type?: string;
+    url?: string;
+}

--- a/resources/js/types/seo-data.d.ts
+++ b/resources/js/types/seo-data.d.ts
@@ -1,0 +1,147 @@
+/**
+ * SeoData type definitions.
+ *
+ * TypeScript types for combined SEO data matching the SeoMetaResource
+ * and SeoPreviewResource API response shapes.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.1.0
+ */
+
+import type { HreflangEntry } from './hreflang';
+import type { MetaTags, MetaTagsResponse } from './meta-tags';
+import type { OpenGraph, OpenGraphResponse } from './open-graph';
+import type { TwitterCard, TwitterCardResponse } from './twitter-card';
+
+/**
+ * Combined SEO data wrapping all meta tag types.
+ */
+export interface SeoData {
+    meta_tags: MetaTags;
+    open_graph: OpenGraph;
+    twitter_card: TwitterCard;
+    hreflang: HreflangEntry[];
+}
+
+/**
+ * Analysis cache summary included in SeoMeta responses.
+ */
+export interface AnalysisCacheSummary {
+    overall_score: number;
+    grade: 'good' | 'ok' | 'poor';
+    analyzed_at: string | null;
+    is_stale: boolean;
+}
+
+/**
+ * Full SEO meta API response from SeoMetaResource.
+ */
+export interface SeoMetaResponse {
+    id: number;
+    seoable_type: string;
+    seoable_id: number;
+    meta_title: string | null;
+    meta_title_length: number;
+    meta_title_warning: string | null;
+    meta_description: string | null;
+    meta_description_length: number;
+    meta_description_warning: string | null;
+    canonical_url: string | null;
+    no_index: boolean;
+    no_follow: boolean;
+    robots_meta: string | null;
+    robots_content: string;
+    is_indexable: boolean;
+    is_followable: boolean;
+    og_title: string | null;
+    og_description: string | null;
+    og_image: string | null;
+    og_image_id: number | null;
+    og_type: string | null;
+    og_locale: string | null;
+    og_site_name: string | null;
+    has_open_graph: boolean;
+    twitter_card: string | null;
+    twitter_title: string | null;
+    twitter_description: string | null;
+    twitter_image: string | null;
+    twitter_image_id: number | null;
+    twitter_site: string | null;
+    twitter_creator: string | null;
+    has_twitter_card: boolean;
+    pinterest_description: string | null;
+    pinterest_image: string | null;
+    pinterest_image_id: number | null;
+    slack_title: string | null;
+    slack_description: string | null;
+    slack_image: string | null;
+    slack_image_id: number | null;
+    schema_type: string | null;
+    schema_markup: Record<string, unknown> | null;
+    has_schema: boolean;
+    focus_keyword: string | null;
+    secondary_keywords: string[] | null;
+    all_keywords: string[];
+    hreflang: HreflangEntry[] | null;
+    sitemap_priority: number | null;
+    sitemap_changefreq: string | null;
+    exclude_from_sitemap: boolean;
+    in_sitemap: boolean;
+    analysis_cache?: AnalysisCacheSummary;
+    created_at: string | null;
+    updated_at: string | null;
+}
+
+/**
+ * SEO preview API response from SeoPreviewResource.
+ */
+export interface SeoPreviewResponse {
+    search: SearchPreview;
+    social: {
+        open_graph: OpenGraphPreview;
+        twitter_card: TwitterCardPreview;
+    };
+    meta: MetaTagsResponse;
+    hreflang: HreflangEntry[];
+}
+
+/**
+ * Google search snippet preview.
+ */
+export interface SearchPreview {
+    title: string;
+    title_truncated: string;
+    title_length: number;
+    title_is_truncated: boolean;
+    description: string;
+    description_truncated: string;
+    description_length: number;
+    description_is_truncated: boolean;
+    url: string;
+}
+
+/**
+ * Open Graph social card preview.
+ */
+export interface OpenGraphPreview {
+    title: string;
+    description: string | null;
+    image: string | null;
+    url: string;
+    site_name: string;
+    type: string;
+}
+
+/**
+ * Twitter Card preview.
+ */
+export interface TwitterCardPreview {
+    card: string;
+    title: string;
+    description: string | null;
+    image: string | null;
+    site: string | null;
+    creator: string | null;
+}

--- a/resources/js/types/twitter-card.d.ts
+++ b/resources/js/types/twitter-card.d.ts
@@ -1,0 +1,40 @@
+/**
+ * TwitterCard type definitions.
+ *
+ * TypeScript types for Twitter Card meta tag data matching the TwitterCardDTO
+ * and TwitterCardResource API response shapes.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.1.0
+ */
+
+/**
+ * Valid Twitter Card type values.
+ */
+export type TwitterCardType = 'summary' | 'summary_large_image' | 'app' | 'player';
+
+/**
+ * Twitter Card data matching TwitterCardDTO properties.
+ */
+export interface TwitterCard {
+    card: TwitterCardType;
+    title: string;
+    description: string | null;
+    image: string | null;
+    site: string | null;
+    creator: string | null;
+}
+
+/**
+ * Twitter Card API response from TwitterCardResource.
+ */
+export interface TwitterCardResponse {
+    card: TwitterCardType;
+    title: string;
+    description: string | null;
+    image: string | null;
+    site: string | null;
+    creator: string | null;
+}

--- a/src/Providers/SEOServiceProvider.php
+++ b/src/Providers/SEOServiceProvider.php
@@ -209,12 +209,21 @@ class SEOServiceProvider extends ServiceProvider
 				'seo-migrations',
 			);
 
+			// Publish TypeScript type definitions
+			$this->publishes(
+				[
+					__DIR__ . '/../../resources/js/types' => resource_path( 'js/types/seo' ),
+				],
+				'seo-types',
+			);
+
 			// Publish all
 			$this->publishes(
 				[
 					__DIR__ . '/../../config/seo.php'       => config_path( 'seo.php' ),
 					__DIR__ . '/../../resources/views'      => resource_path( 'views/vendor/seo' ),
 					__DIR__ . '/../../database/migrations'  => database_path( 'migrations' ),
+					__DIR__ . '/../../resources/js/types'   => resource_path( 'js/types/seo' ),
 				],
 				'seo',
 			);

--- a/tests/Feature/TypeScriptTypesPublishTest.php
+++ b/tests/Feature/TypeScriptTypesPublishTest.php
@@ -1,0 +1,251 @@
+<?php
+
+/**
+ * TypeScript Types Publish Tests.
+ *
+ * Feature tests verifying that TypeScript type definitions
+ * are publishable and contain the expected type files.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+describe( 'TypeScript Types Publishing', function (): void {
+
+	it( 'registers seo-types as a publishable tag', function (): void {
+		$publishableGroups = Illuminate\Support\ServiceProvider::$publishGroups;
+
+		expect( $publishableGroups )->toHaveKey( 'seo-types' );
+	} );
+
+	it( 'publishes type files to the correct destination', function (): void {
+		$publishableGroups = Illuminate\Support\ServiceProvider::$publishGroups;
+		$typesPublishable  = $publishableGroups['seo-types'] ?? [];
+
+		// Find the key that ends with resources/js/types
+		$sourceKey = collect( array_keys( $typesPublishable ) )
+			->first( fn ( string $key ) => str_ends_with( $key, 'resources/js/types' ) );
+
+		expect( $sourceKey )->not->toBeNull();
+		expect( $typesPublishable[ $sourceKey ] )->toBe( resource_path( 'js/types/seo' ) );
+	} );
+
+	it( 'includes types in the seo publish group', function (): void {
+		$publishableGroups = Illuminate\Support\ServiceProvider::$publishGroups;
+		$seoPublishable    = $publishableGroups['seo'] ?? [];
+
+		$sourceKey = collect( array_keys( $seoPublishable ) )
+			->first( fn ( string $key ) => str_ends_with( $key, 'resources/js/types' ) );
+
+		expect( $sourceKey )->not->toBeNull();
+	} );
+
+	it( 'has all expected type definition files', function (): void {
+		$typesDir      = __DIR__ . '/../../resources/js/types';
+		$expectedFiles = [
+			'index.d.ts',
+			'meta-tags.d.ts',
+			'open-graph.d.ts',
+			'twitter-card.d.ts',
+			'hreflang.d.ts',
+			'seo-data.d.ts',
+			'analysis.d.ts',
+			'schema.d.ts',
+			'redirect.d.ts',
+			'components.d.ts',
+		];
+
+		foreach ( $expectedFiles as $file ) {
+			expect( file_exists( $typesDir . '/' . $file ) )->toBeTrue();
+		}
+	} );
+
+	it( 'contains no unexpected files in the types directory', function (): void {
+		$typesDir      = __DIR__ . '/../../resources/js/types';
+		$expectedFiles = [
+			'index.d.ts',
+			'meta-tags.d.ts',
+			'open-graph.d.ts',
+			'twitter-card.d.ts',
+			'hreflang.d.ts',
+			'seo-data.d.ts',
+			'analysis.d.ts',
+			'schema.d.ts',
+			'redirect.d.ts',
+			'components.d.ts',
+		];
+
+		$actualFiles = array_map(
+			'basename',
+			glob( $typesDir . '/*.d.ts' ),
+		);
+
+		sort( $actualFiles );
+		sort( $expectedFiles );
+
+		expect( $actualFiles )->toBe( $expectedFiles );
+	} );
+
+	it( 'type files contain valid TypeScript export declarations', function (): void {
+		$typesDir = __DIR__ . '/../../resources/js/types';
+		$files    = glob( $typesDir . '/*.d.ts' );
+
+		foreach ( $files as $file ) {
+			$content = file_get_contents( $file );
+
+			expect( $content )->toContain( 'export' );
+		}
+	} );
+
+	it( 'index.d.ts re-exports from all module files', function (): void {
+		$indexContent = file_get_contents( __DIR__ . '/../../resources/js/types/index.d.ts' );
+		$modules      = [
+			'./meta-tags',
+			'./open-graph',
+			'./twitter-card',
+			'./hreflang',
+			'./seo-data',
+			'./analysis',
+			'./schema',
+			'./redirect',
+			'./components',
+		];
+
+		foreach ( $modules as $module ) {
+			expect( $indexContent )->toContain( $module );
+		}
+	} );
+
+	it( 'meta-tags types contain MetaTags interface', function (): void {
+		$content = file_get_contents( __DIR__ . '/../../resources/js/types/meta-tags.d.ts' );
+
+		expect( $content )->toContain( 'export interface MetaTags' )
+			->and( $content )->toContain( 'export interface MetaTagsResponse' )
+			->and( $content )->toContain( 'title: string' )
+			->and( $content )->toContain( 'description: string | null' )
+			->and( $content )->toContain( 'canonical: string' )
+			->and( $content )->toContain( 'robots: string' );
+	} );
+
+	it( 'open-graph types contain OpenGraph interface and type union', function (): void {
+		$content = file_get_contents( __DIR__ . '/../../resources/js/types/open-graph.d.ts' );
+
+		expect( $content )->toContain( 'export type OpenGraphType' )
+			->and( $content )->toContain( 'export interface OpenGraph' )
+			->and( $content )->toContain( "'website'" )
+			->and( $content )->toContain( "'article'" );
+	} );
+
+	it( 'twitter-card types contain TwitterCard interface and type union', function (): void {
+		$content = file_get_contents( __DIR__ . '/../../resources/js/types/twitter-card.d.ts' );
+
+		expect( $content )->toContain( 'export type TwitterCardType' )
+			->and( $content )->toContain( 'export interface TwitterCard' )
+			->and( $content )->toContain( "'summary'" )
+			->and( $content )->toContain( "'summary_large_image'" );
+	} );
+
+	it( 'analysis types contain all analyzer names', function (): void {
+		$content       = file_get_contents( __DIR__ . '/../../resources/js/types/analysis.d.ts' );
+		$analyzerNames = [
+			'content_length',
+			'focus_keyword',
+			'heading_structure',
+			'image_alt',
+			'internal_link',
+			'keyword_density',
+			'meta_length',
+			'readability',
+		];
+
+		expect( $content )->toContain( 'export type AnalyzerName' );
+
+		foreach ( $analyzerNames as $name ) {
+			expect( $content )->toContain( "'{$name}'" );
+		}
+	} );
+
+	it( 'schema types contain all 13 schema type names', function (): void {
+		$content     = file_get_contents( __DIR__ . '/../../resources/js/types/schema.d.ts' );
+		$schemaTypes = [
+			'Organization',
+			'LocalBusiness',
+			'WebSite',
+			'WebPage',
+			'Article',
+			'BlogPosting',
+			'Product',
+			'Service',
+			'Event',
+			'FAQPage',
+			'BreadcrumbList',
+			'Review',
+			'AggregateRating',
+		];
+
+		expect( $content )->toContain( 'export type SchemaType' );
+
+		foreach ( $schemaTypes as $type ) {
+			expect( $content )->toContain( "'{$type}'" );
+		}
+	} );
+
+	it( 'schema types contain per-type config interfaces', function (): void {
+		$content          = file_get_contents( __DIR__ . '/../../resources/js/types/schema.d.ts' );
+		$configInterfaces = [
+			'ArticleSchemaConfig',
+			'ProductSchemaConfig',
+			'EventSchemaConfig',
+			'FAQPageSchemaConfig',
+			'BreadcrumbListSchemaConfig',
+			'OrganizationSchemaConfig',
+			'LocalBusinessSchemaConfig',
+			'WebSiteSchemaConfig',
+			'WebPageSchemaConfig',
+			'ServiceSchemaConfig',
+			'ReviewSchemaConfig',
+			'AggregateRatingSchemaConfig',
+		];
+
+		foreach ( $configInterfaces as $interface ) {
+			expect( $content )->toContain( "export interface {$interface}" );
+		}
+	} );
+
+	it( 'redirect types contain status code and match type unions', function (): void {
+		$content = file_get_contents( __DIR__ . '/../../resources/js/types/redirect.d.ts' );
+
+		expect( $content )->toContain( 'export type RedirectStatusCode' )
+			->and( $content )->toContain( '301' )
+			->and( $content )->toContain( '302' )
+			->and( $content )->toContain( '307' )
+			->and( $content )->toContain( '308' )
+			->and( $content )->toContain( 'export type RedirectMatchType' )
+			->and( $content )->toContain( "'exact'" )
+			->and( $content )->toContain( "'regex'" )
+			->and( $content )->toContain( "'wildcard'" );
+	} );
+
+	it( 'component types contain SeoEditorProps and RedirectManagerProps', function (): void {
+		$content = file_get_contents( __DIR__ . '/../../resources/js/types/components.d.ts' );
+
+		expect( $content )->toContain( 'export interface SeoEditorProps' )
+			->and( $content )->toContain( 'export interface RedirectManagerProps' )
+			->and( $content )->toContain( 'modelType: string' )
+			->and( $content )->toContain( 'modelId: number' );
+	} );
+
+	it( 'schema types contain SchemaFieldDefinition for dynamic forms', function (): void {
+		$content = file_get_contents( __DIR__ . '/../../resources/js/types/schema.d.ts' );
+
+		expect( $content )->toContain( 'export interface SchemaFieldDefinition' )
+			->and( $content )->toContain( 'export type SchemaFieldType' )
+			->and( $content )->toContain( 'name: string' )
+			->and( $content )->toContain( 'required: boolean' )
+			->and( $content )->toContain( 'description: string' );
+	} );
+} );

--- a/tests/Feature/TypeScriptTypesPublishTest.php
+++ b/tests/Feature/TypeScriptTypesPublishTest.php
@@ -34,7 +34,7 @@ describe( 'TypeScript Types Publishing', function (): void {
 		expect( $typesPublishable[ $sourceKey ] )->toBe( resource_path( 'js/types/seo' ) );
 	} );
 
-	it( 'includes types in the seo publish group', function (): void {
+	it( 'includes types in the seo publish group with correct destination', function (): void {
 		$publishableGroups = Illuminate\Support\ServiceProvider::$publishGroups;
 		$seoPublishable    = $publishableGroups['seo'] ?? [];
 
@@ -42,6 +42,7 @@ describe( 'TypeScript Types Publishing', function (): void {
 			->first( fn ( string $key ) => str_ends_with( $key, 'resources/js/types' ) );
 
 		expect( $sourceKey )->not->toBeNull();
+		expect( $seoPublishable[ $sourceKey ] )->toBe( resource_path( 'js/types/seo' ) );
 	} );
 
 	it( 'has all expected type definition files', function (): void {
@@ -131,13 +132,29 @@ describe( 'TypeScript Types Publishing', function (): void {
 			->and( $content )->toContain( 'robots: string' );
 	} );
 
-	it( 'open-graph types contain OpenGraph interface and type union', function (): void {
+	it( 'open-graph types contain OpenGraph interface and full type union', function (): void {
 		$content = file_get_contents( __DIR__ . '/../../resources/js/types/open-graph.d.ts' );
+		$ogTypes = [
+			'website',
+			'article',
+			'book',
+			'profile',
+			'music.song',
+			'music.album',
+			'music.playlist',
+			'music.radio_station',
+			'video.movie',
+			'video.episode',
+			'video.tv_show',
+			'video.other',
+		];
 
 		expect( $content )->toContain( 'export type OpenGraphType' )
-			->and( $content )->toContain( 'export interface OpenGraph' )
-			->and( $content )->toContain( "'website'" )
-			->and( $content )->toContain( "'article'" );
+			->and( $content )->toContain( 'export interface OpenGraph' );
+
+		foreach ( $ogTypes as $type ) {
+			expect( $content )->toContain( "'{$type}'" );
+		}
 	} );
 
 	it( 'twitter-card types contain TwitterCard interface and type union', function (): void {

--- a/tests/Feature/TypeScriptTypesPublishTest.php
+++ b/tests/Feature/TypeScriptTypesPublishTest.php
@@ -156,7 +156,7 @@ describe( 'TypeScript Types Publishing', function (): void {
 			'focus_keyword',
 			'heading_structure',
 			'image_alt',
-			'internal_link',
+			'internal_links',
 			'keyword_density',
 			'meta_length',
 			'readability',


### PR DESCRIPTION
## Description

Create and publish TypeScript type definitions for all SEO package API responses, enabling full type safety in React/Vue SEO editor components.

**Closes:** #31

## Type of Change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds new functionality)
- [x] Enhancement (improves existing functionality)
- [ ] Refactoring (code improvement, no behavior change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security fix
- [ ] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** #31

## Motivation and Context

React and Vue SEO editor components need TypeScript type definitions for meta tags, Open Graph, Twitter Cards, schema types, redirects, analysis results, and hreflang data. Without these types, consumers of the SEO API would have no type safety when building frontend components.

## Changes Made

- Created 10 TypeScript type definition files in `resources/js/types/`:
  - `meta-tags.d.ts` — `MetaTags`, `MetaTagsResponse`
  - `open-graph.d.ts` — `OpenGraph`, `OpenGraphResponse`, `OpenGraphType` (12 OG types)
  - `twitter-card.d.ts` — `TwitterCard`, `TwitterCardResponse`, `TwitterCardType` (4 card types)
  - `hreflang.d.ts` — `HreflangEntry`
  - `seo-data.d.ts` — `SeoData`, `SeoMetaResponse`, `SeoPreviewResponse`, `SearchPreview`
  - `analysis.d.ts` — `AnalysisResult`, `AnalysisResultResponse`, `AnalyzerName` (8 analyzers), `AnalyzerResult`
  - `schema.d.ts` — `SchemaType` (13 types), per-type config interfaces, `SchemaFieldDefinition`, helper types
  - `redirect.d.ts` — `Redirect`, `RedirectTestResult`, `RedirectStatusCode`, `RedirectMatchType`
  - `components.d.ts` — `SeoEditorProps`, `RedirectManagerProps`, filter/sort types
  - `index.d.ts` — Barrel export re-exporting all types
- Added `seo-types` publish tag to SEOServiceProvider
- Included types in the `seo` catch-all publish group

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- PHP Version: 8.4.3
- Project Version: 1.1.0-dev

**Tests Performed:**
1. Ran full test suite (1301 tests, all passing)
2. Verified publishable tag registration
3. Verified type file content and structure

## Accessibility Tests Run

- [x] N/A — TypeScript type definitions only, no UI changes

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:** Added `tests/Feature/TypeScriptTypesPublishTest.php` with 16 tests covering:
- Publishable tag registration (`seo-types` and `seo` groups)
- All 10 expected `.d.ts` files exist
- No unexpected files in types directory
- All files contain export declarations
- `index.d.ts` re-exports from all module files
- MetaTags, OpenGraph, TwitterCard interface content verification
- All 8 analyzer names present in analysis types
- All 13 schema type names present
- All 12 per-type schema config interfaces present
- SchemaFieldDefinition for dynamic form rendering
- Redirect status codes and match type unions
- Component prop type interfaces

## Documentation

- [x] Inline code documentation added

**Documentation details:** All type files include JSDoc comments with `@package`, `@subpackage`, and `@since` tags. The `index.d.ts` barrel export includes publish instructions.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added comprehensive TypeScript type definitions for SEO features: meta tags, social previews (Open Graph, Twitter), hreflang, redirects, schema markup, SEO analysis, and component props; consolidated public type exports for easier imports.
  * Enabled publishing of those type definitions for consuming projects.

* **Tests**
  * Added tests verifying type-definition publishing and the presence/content of the generated declaration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->