### PR TITLE
enhancement: Create Vue SEO admin components

### DIFF
--- a/resources/js/vue/components/admin/BasicMetaTab.vue
+++ b/resources/js/vue/components/admin/BasicMetaTab.vue
@@ -1,0 +1,113 @@
+<!--
+  BasicMetaTab component.
+
+  Tab for editing basic SEO meta fields: title, description,
+  canonical URL, focus keyword, and robots directives.
+
+  @package    ArtisanPack_UI
+  @subpackage SEO
+
+  @since      1.1.0
+-->
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+import { Alert, Checkbox, Divider, Input, Textarea } from '@artisanpack-ui/vue';
+
+import type { SeoMetaResponse } from '../../../types/seo-data';
+
+const MAX_TITLE_LENGTH = 60;
+const MAX_DESC_LENGTH  = 160;
+
+const props = defineProps<{
+	/** Current SEO meta data. */
+	data: SeoMetaResponse;
+	/** Validation errors keyed by field name. */
+	errors?: Record<string, string[]>;
+}>();
+
+const emit = defineEmits<{
+	'change': [field: string, value: unknown];
+}>();
+
+const titleLength = computed( () => props.data.meta_title?.length ?? 0 );
+const descLength  = computed( () => props.data.meta_description?.length ?? 0 );
+
+const titleHint = computed( () =>
+	`${ titleLength.value }/${ MAX_TITLE_LENGTH } characters${ titleLength.value > MAX_TITLE_LENGTH ? ' (too long)' : '' }`,
+);
+
+const descHint = computed( () =>
+	`${ descLength.value }/${ MAX_DESC_LENGTH } characters${ descLength.value > MAX_DESC_LENGTH ? ' (too long)' : '' }`,
+);
+</script>
+
+<template>
+	<div class="flex flex-col gap-4">
+		<Input
+			label="Meta Title"
+			:model-value="data.meta_title ?? ''"
+			@update:model-value="emit( 'change', 'meta_title', $event )"
+			:hint="titleHint"
+			:error="errors?.meta_title?.[0]"
+			:maxlength="255"
+		/>
+
+		<Textarea
+			label="Meta Description"
+			:model-value="data.meta_description ?? ''"
+			@update:model-value="emit( 'change', 'meta_description', $event )"
+			:hint="descHint"
+			:error="errors?.meta_description?.[0]"
+			:rows="3"
+		/>
+
+		<Input
+			label="Canonical URL"
+			:model-value="data.canonical_url ?? ''"
+			@update:model-value="emit( 'change', 'canonical_url', $event )"
+			hint="Leave blank to use the default URL"
+			:error="errors?.canonical_url?.[0]"
+			type="url"
+		/>
+
+		<Input
+			label="Focus Keyword"
+			:model-value="data.focus_keyword ?? ''"
+			@update:model-value="emit( 'change', 'focus_keyword', $event )"
+			hint="The primary keyword to optimize for"
+			:error="errors?.focus_keyword?.[0]"
+		/>
+
+		<Input
+			label="Secondary Keywords"
+			:model-value="data.secondary_keywords?.join( ', ' ) ?? ''"
+			@update:model-value="emit( 'change', 'secondary_keywords', String( $event ).split( ',' ).map( k => k.trim() ).filter( Boolean ) )"
+			hint="Comma-separated list of additional keywords"
+			:error="errors?.secondary_keywords?.[0]"
+		/>
+
+		<Divider label="Robots Directives" />
+
+		<div class="flex flex-col gap-2">
+			<Checkbox
+				label="No Index"
+				:model-value="data.no_index"
+				@update:model-value="emit( 'change', 'no_index', $event )"
+				hint="Prevent search engines from indexing this page"
+			/>
+
+			<Checkbox
+				label="No Follow"
+				:model-value="data.no_follow"
+				@update:model-value="emit( 'change', 'no_follow', $event )"
+				hint="Prevent search engines from following links on this page"
+			/>
+		</div>
+
+		<Alert v-if="data.no_index" color="warning">
+			This page will not appear in search engine results.
+		</Alert>
+	</div>
+</template>

--- a/resources/js/vue/components/admin/HreflangTab.vue
+++ b/resources/js/vue/components/admin/HreflangTab.vue
@@ -1,0 +1,113 @@
+<!--
+  HreflangTab component.
+
+  Tab for editing hreflang language/region URL mappings
+  with add/remove rows and x-default support.
+
+  @package    ArtisanPack_UI
+  @subpackage SEO
+
+  @since      1.1.0
+-->
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+import { Alert, Button, Input } from '@artisanpack-ui/vue';
+
+import type { HreflangEntry } from '../../../types/hreflang';
+import type { SeoMetaResponse } from '../../../types/seo-data';
+
+const props = defineProps<{
+	data: SeoMetaResponse;
+	errors?: Record<string, string[]>;
+}>();
+
+const emit = defineEmits<{
+	'change': [entries: HreflangEntry[]];
+}>();
+
+const entries    = computed( () => props.data.hreflang ?? [] );
+const hasXDefault = computed( () => entries.value.some( ( e ) => 'x-default' === e.hreflang ) );
+
+function addEntry(): void {
+	emit( 'change', [...entries.value, { hreflang: '', href: '' }] );
+}
+
+function addXDefault(): void {
+	if ( !hasXDefault.value ) {
+		emit( 'change', [...entries.value, { hreflang: 'x-default', href: '' }] );
+	}
+}
+
+function updateEntry( index: number, field: keyof HreflangEntry, value: string ): void {
+	const updated = entries.value.map( ( entry, i ) =>
+		i === index ? { ...entry, [field]: value } : entry,
+	);
+	emit( 'change', updated );
+}
+
+function removeEntry( index: number ): void {
+	emit( 'change', entries.value.filter( ( _, i ) => i !== index ) );
+}
+</script>
+
+<template>
+	<div class="flex flex-col gap-4">
+		<Alert color="info">
+			Hreflang tags tell search engines about alternate language versions of your content.
+			Use ISO 639-1 language codes (e.g. "en", "fr", "de")
+			optionally combined with ISO 3166-1 country codes (e.g. "en-US", "fr-CA").
+		</Alert>
+
+		<p v-if="entries.length === 0" class="text-base-content/60 text-sm">
+			No hreflang entries. Click "Add Entry" to add alternate language URLs.
+		</p>
+
+		<div
+			v-for="( entry, index ) in entries"
+			:key="index"
+			class="flex gap-2 items-end"
+		>
+			<Input
+				:label="index === 0 ? 'Language Code' : undefined"
+				:model-value="entry.hreflang"
+				@update:model-value="updateEntry( index, 'hreflang', String( $event ) )"
+				placeholder="e.g. en-US"
+				:error="errors?.[`hreflang.${ index }.hreflang`]?.[0]"
+				:disabled="entry.hreflang === 'x-default'"
+				class="w-36"
+			/>
+
+			<div class="flex-1">
+				<Input
+					:label="index === 0 ? 'URL' : undefined"
+					:model-value="entry.href"
+					@update:model-value="updateEntry( index, 'href', String( $event ) )"
+					placeholder="https://example.com/page"
+					:error="errors?.[`hreflang.${ index }.href`]?.[0]"
+					type="url"
+				/>
+			</div>
+
+			<Button
+				color="error"
+				size="sm"
+				@click="removeEntry( index )"
+				:aria-label="`Remove entry ${ index + 1 }`"
+			>
+				Remove
+			</Button>
+		</div>
+
+		<div class="flex gap-2">
+			<Button color="primary" size="sm" @click="addEntry">
+				Add Entry
+			</Button>
+
+			<Button v-if="!hasXDefault" size="sm" @click="addXDefault">
+				Add x-default
+			</Button>
+		</div>
+	</div>
+</template>

--- a/resources/js/vue/components/admin/MetaPreview.vue
+++ b/resources/js/vue/components/admin/MetaPreview.vue
@@ -1,0 +1,76 @@
+<!--
+  MetaPreview component.
+
+  Displays a live Google search result snippet preview showing
+  how the page will appear in search engine results.
+
+  @package    ArtisanPack_UI
+  @subpackage SEO
+
+  @since      1.1.0
+-->
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+import { Card } from '@artisanpack-ui/vue';
+
+import type { SeoMetaResponse } from '../../../types/seo-data';
+
+const MAX_TITLE_LENGTH = 60;
+const MAX_DESC_LENGTH  = 160;
+
+const props = withDefaults( defineProps<{
+	data: SeoMetaResponse;
+	defaultUrl?: string;
+	className?: string;
+}>(), {
+	defaultUrl: '',
+	className: undefined,
+} );
+
+const title = computed( () => props.data.meta_title || 'Page Title' );
+const description = computed( () => props.data.meta_description || 'No description set. Search engines will generate a snippet from the page content.' );
+const url = computed( () => props.data.canonical_url || props.defaultUrl || 'https://example.com' );
+
+const truncatedTitle = computed( () => {
+	if ( title.value.length <= MAX_TITLE_LENGTH ) {
+		return title.value;
+	}
+
+	return title.value.slice( 0, MAX_TITLE_LENGTH - 3 ) + '...';
+} );
+
+const truncatedDesc = computed( () => {
+	if ( description.value.length <= MAX_DESC_LENGTH ) {
+		return description.value;
+	}
+
+	return description.value.slice( 0, MAX_DESC_LENGTH - 3 ) + '...';
+} );
+
+const displayUrl = computed( () => {
+	try {
+		const parsed = new URL( url.value );
+
+		return `${ parsed.hostname }${ parsed.pathname }`;
+	} catch {
+		return url.value;
+	}
+} );
+</script>
+
+<template>
+	<Card :class="className">
+		<div class="p-4">
+			<p class="text-xs text-base-content/50 mb-2">Google Search Preview</p>
+			<div class="max-w-xl">
+				<p class="text-sm text-base-content/60 mb-0.5">{{ displayUrl }}</p>
+				<h3 class="text-lg text-primary hover:underline cursor-pointer leading-tight mb-1">
+					{{ truncatedTitle }}
+				</h3>
+				<p class="text-sm text-base-content/70 leading-snug">{{ truncatedDesc }}</p>
+			</div>
+		</div>
+	</Card>
+</template>

--- a/resources/js/vue/components/admin/OpenGraphTab.vue
+++ b/resources/js/vue/components/admin/OpenGraphTab.vue
@@ -1,0 +1,97 @@
+<!--
+  OpenGraphTab component.
+
+  Tab for editing Open Graph meta fields including type, title,
+  description, image, URL, site name, and locale.
+
+  @package    ArtisanPack_UI
+  @subpackage SEO
+
+  @since      1.1.0
+-->
+
+<script setup lang="ts">
+import { Input, Select, Textarea } from '@artisanpack-ui/vue';
+
+import type { SeoMetaResponse } from '../../../types/seo-data';
+
+const OG_TYPE_OPTIONS = [
+	{ value: 'website', name: 'Website' },
+	{ value: 'article', name: 'Article' },
+	{ value: 'book', name: 'Book' },
+	{ value: 'profile', name: 'Profile' },
+	{ value: 'music.song', name: 'Music - Song' },
+	{ value: 'music.album', name: 'Music - Album' },
+	{ value: 'music.playlist', name: 'Music - Playlist' },
+	{ value: 'music.radio_station', name: 'Music - Radio Station' },
+	{ value: 'video.movie', name: 'Video - Movie' },
+	{ value: 'video.episode', name: 'Video - Episode' },
+	{ value: 'video.tv_show', name: 'Video - TV Show' },
+	{ value: 'video.other', name: 'Video - Other' },
+];
+
+defineProps<{
+	data: SeoMetaResponse;
+	errors?: Record<string, string[]>;
+}>();
+
+const emit = defineEmits<{
+	'change': [field: string, value: unknown];
+}>();
+</script>
+
+<template>
+	<div class="flex flex-col gap-4">
+		<Select
+			label="OG Type"
+			:model-value="data.og_type ?? 'website'"
+			@update:model-value="emit( 'change', 'og_type', $event )"
+			:options="OG_TYPE_OPTIONS"
+			option-value="value"
+			option-label="name"
+			:error="errors?.og_type?.[0]"
+		/>
+
+		<Input
+			label="OG Title"
+			:model-value="data.og_title ?? ''"
+			@update:model-value="emit( 'change', 'og_title', $event )"
+			hint="Leave blank to use the meta title"
+			:error="errors?.og_title?.[0]"
+		/>
+
+		<Textarea
+			label="OG Description"
+			:model-value="data.og_description ?? ''"
+			@update:model-value="emit( 'change', 'og_description', $event )"
+			hint="Leave blank to use the meta description"
+			:error="errors?.og_description?.[0]"
+			:rows="3"
+		/>
+
+		<Input
+			label="OG Image URL"
+			:model-value="data.og_image ?? ''"
+			@update:model-value="emit( 'change', 'og_image', $event )"
+			hint="Recommended size: 1200x630 pixels"
+			:error="errors?.og_image?.[0]"
+			type="url"
+		/>
+
+		<Input
+			label="Site Name"
+			:model-value="data.og_site_name ?? ''"
+			@update:model-value="emit( 'change', 'og_site_name', $event )"
+			hint="Leave blank to use the site default"
+			:error="errors?.og_site_name?.[0]"
+		/>
+
+		<Input
+			label="Locale"
+			:model-value="data.og_locale ?? ''"
+			@update:model-value="emit( 'change', 'og_locale', $event )"
+			hint="e.g. en_US, fr_FR"
+			:error="errors?.og_locale?.[0]"
+		/>
+	</div>
+</template>

--- a/resources/js/vue/components/admin/RedirectManager.vue
+++ b/resources/js/vue/components/admin/RedirectManager.vue
@@ -1,0 +1,473 @@
+<!--
+  RedirectManager component.
+
+  CRUD table for URL redirects with filtering, sorting, pagination,
+  bulk actions, and a URL test tool.
+
+  @package    ArtisanPack_UI
+  @subpackage SEO
+
+  @since      1.1.0
+-->
+
+<script setup lang="ts">
+import { computed, onUnmounted, ref, watch } from 'vue';
+
+import {
+	Alert,
+	Badge,
+	Button,
+	Card,
+	Checkbox,
+	Input,
+	Modal,
+	Pagination,
+	Select,
+	Textarea,
+} from '@artisanpack-ui/vue';
+
+import type { UseApiOptions } from '../../composables/useApi';
+import { useRedirects } from '../../composables/useRedirects';
+
+import type { Redirect, RedirectMatchType, RedirectStatusCode } from '../../../types/redirect';
+import type { RedirectSortField, SortDirection } from '../../../types/components';
+
+const STATUS_CODE_OPTIONS = [
+	{ value: '', name: 'All Status Codes' },
+	{ value: '301', name: '301 - Permanent' },
+	{ value: '302', name: '302 - Temporary' },
+	{ value: '307', name: '307 - Temporary (Strict)' },
+	{ value: '308', name: '308 - Permanent (Strict)' },
+];
+
+const MATCH_TYPE_OPTIONS = [
+	{ value: '', name: 'All Match Types' },
+	{ value: 'exact', name: 'Exact' },
+	{ value: 'regex', name: 'Regex' },
+	{ value: 'wildcard', name: 'Wildcard' },
+];
+
+const FORM_STATUS_OPTIONS = STATUS_CODE_OPTIONS.slice( 1 );
+const FORM_MATCH_OPTIONS  = MATCH_TYPE_OPTIONS.slice( 1 );
+
+interface RedirectFormData {
+	from_path: string;
+	to_path: string;
+	status_code: string;
+	match_type: string;
+	is_active: boolean;
+	notes: string;
+}
+
+const EMPTY_FORM: RedirectFormData = {
+	from_path: '',
+	to_path: '',
+	status_code: '301',
+	match_type: 'exact',
+	is_active: true,
+	notes: '',
+};
+
+const props = withDefaults( defineProps<UseApiOptions & {
+	className?: string;
+}>(), {
+	csrfToken: undefined,
+	authorization: undefined,
+	credentials: undefined,
+	className: undefined,
+} );
+
+const {
+	redirects,
+	meta,
+	loading,
+	mutating,
+	error,
+	validationErrors,
+	filters,
+	sort,
+	page,
+	createRedirect,
+	updateRedirect,
+	deleteRedirect,
+	bulkAction,
+	testUrl,
+	setFilters,
+	setSort,
+	setPage,
+} = useRedirects( {
+	baseUrl: props.baseUrl,
+	csrfToken: props.csrfToken,
+	authorization: props.authorization,
+	credentials: props.credentials,
+} );
+
+const showCreateModal  = ref( false );
+const editingRedirect  = ref<Redirect | null>( null );
+const formData         = ref<RedirectFormData>( { ...EMPTY_FORM } );
+const selectedIds      = ref<Set<number>>( new Set() );
+const testUrlValue     = ref( '' );
+const testResult       = ref<string | null>( null );
+const searchValue      = ref( '' );
+let searchTimer: ReturnType<typeof setTimeout> | null = null;
+
+onUnmounted( () => {
+	if ( searchTimer ) {
+		clearTimeout( searchTimer );
+		searchTimer = null;
+	}
+} );
+
+// Clear selection when visible list changes
+watch( [redirects, page, filters], () => {
+	selectedIds.value = new Set();
+}, { deep: true } );
+
+function handleSearchChange( value: string ): void {
+	searchValue.value = String( value );
+
+	if ( searchTimer ) {
+		clearTimeout( searchTimer );
+	}
+
+	searchTimer = setTimeout( () => {
+		setFilters( { ...filters.value, search: searchValue.value || undefined } );
+	}, 300 );
+}
+
+function openCreate(): void {
+	formData.value = { ...EMPTY_FORM };
+	showCreateModal.value = true;
+}
+
+function openEdit( redirect: Redirect ): void {
+	formData.value = {
+		from_path: redirect.from_path,
+		to_path: redirect.to_path,
+		status_code: String( redirect.status_code ),
+		match_type: redirect.match_type,
+		is_active: redirect.is_active,
+		notes: redirect.notes ?? '',
+	};
+	editingRedirect.value = redirect;
+}
+
+function closeModals(): void {
+	showCreateModal.value = false;
+	editingRedirect.value = null;
+	formData.value        = { ...EMPTY_FORM };
+}
+
+async function handleCreate(): Promise<void> {
+	const result = await createRedirect( {
+		...formData.value,
+		status_code: parseInt( formData.value.status_code, 10 ),
+	} );
+
+	if ( result ) {
+		closeModals();
+	}
+}
+
+async function handleUpdate(): Promise<void> {
+	if ( !editingRedirect.value ) {
+		return;
+	}
+
+	const result = await updateRedirect( editingRedirect.value.id, {
+		...formData.value,
+		status_code: parseInt( formData.value.status_code, 10 ),
+	} );
+
+	if ( result ) {
+		closeModals();
+	}
+}
+
+async function handleDelete( id: number ): Promise<void> {
+	if ( window.confirm( 'Are you sure you want to delete this redirect?' ) ) {
+		await deleteRedirect( id );
+	}
+}
+
+async function handleBulkDelete(): Promise<void> {
+	if ( 0 === selectedIds.value.size ) {
+		return;
+	}
+
+	if ( window.confirm( `Delete ${ selectedIds.value.size } selected redirect(s)?` ) ) {
+		const success = await bulkAction( 'delete', Array.from( selectedIds.value ) );
+
+		if ( success ) {
+			selectedIds.value = new Set();
+		}
+	}
+}
+
+function toggleSelectAll(): void {
+	if ( selectedIds.value.size === redirects.value.length ) {
+		selectedIds.value = new Set();
+	} else {
+		selectedIds.value = new Set( redirects.value.map( ( r ) => r.id ) );
+	}
+}
+
+function toggleSelect( id: number ): void {
+	const next = new Set( selectedIds.value );
+
+	if ( next.has( id ) ) {
+		next.delete( id );
+	} else {
+		next.add( id );
+	}
+
+	selectedIds.value = next;
+}
+
+async function handleTestUrl(): Promise<void> {
+	if ( !testUrlValue.value.trim() ) {
+		return;
+	}
+
+	const result = await testUrl( testUrlValue.value );
+
+	if ( null === result ) {
+		testResult.value = 'Error testing URL — please try again.';
+	} else if ( result.matched ) {
+		testResult.value = `Matches redirect #${ result.matched.id }: ${ result.matched.from_path } -> ${ result.resolved_destination }`;
+	} else {
+		testResult.value = 'No matching redirect found.';
+	}
+}
+
+function handleSort( field: RedirectSortField ): void {
+	const direction: SortDirection = sort.value.field === field && 'asc' === sort.value.direction ? 'desc' : 'asc';
+	setSort( { field, direction } );
+}
+
+function sortIndicator( field: RedirectSortField ): string {
+	if ( sort.value.field !== field ) {
+		return '';
+	}
+
+	return 'asc' === sort.value.direction ? ' \u2191' : ' \u2193';
+}
+
+function handleSortKeydown( event: KeyboardEvent, field: RedirectSortField ): void {
+	if ( 'Enter' === event.key || ' ' === event.key ) {
+		event.preventDefault();
+		handleSort( field );
+	}
+}
+
+const allSelected = computed( () => redirects.value.length > 0 && selectedIds.value.size === redirects.value.length );
+</script>
+
+<template>
+	<div :class="className">
+		<Alert v-if="error" color="error" class="mb-4">{{ error }}</Alert>
+
+		<!-- Toolbar -->
+		<div class="flex flex-wrap items-center gap-2 mb-4">
+			<Input
+				:model-value="searchValue"
+				@update:model-value="handleSearchChange( String( $event ) )"
+				placeholder="Search redirects..."
+				class="w-64"
+			/>
+
+			<Select
+				:model-value="filters.status_code ? String( filters.status_code ) : ''"
+				@update:model-value="setFilters( { ...filters, status_code: $event ? parseInt( String( $event ), 10 ) as RedirectStatusCode : undefined } )"
+				:options="STATUS_CODE_OPTIONS"
+				option-value="value"
+				option-label="name"
+				class="w-48"
+			/>
+
+			<Select
+				:model-value="filters.match_type ?? ''"
+				@update:model-value="setFilters( { ...filters, match_type: ( String( $event ) || undefined ) as RedirectMatchType | undefined } )"
+				:options="MATCH_TYPE_OPTIONS"
+				option-value="value"
+				option-label="name"
+				class="w-44"
+			/>
+
+			<div class="ml-auto flex gap-2">
+				<Button
+					v-if="selectedIds.size > 0"
+					color="error"
+					size="sm"
+					@click="handleBulkDelete"
+					:disabled="mutating"
+				>
+					Delete Selected ({{ selectedIds.size }})
+				</Button>
+
+				<Button color="primary" size="sm" @click="openCreate">
+					Add Redirect
+				</Button>
+			</div>
+		</div>
+
+		<!-- URL Test Tool -->
+		<Card class="mb-4">
+			<div class="p-3 flex gap-2 items-end">
+				<Input
+					label="Test URL"
+					v-model="testUrlValue"
+					placeholder="Enter a URL path to test..."
+					class="flex-1"
+				/>
+				<Button size="sm" @click="handleTestUrl">Test</Button>
+			</div>
+			<div v-if="testResult" class="px-3 pb-3">
+				<Alert color="info">{{ testResult }}</Alert>
+			</div>
+		</Card>
+
+		<!-- Table -->
+		<Loading v-if="loading" />
+
+		<template v-else>
+			<div class="overflow-x-auto">
+				<table class="table table-zebra w-full">
+					<thead>
+						<tr>
+							<th class="w-10">
+								<Checkbox
+									:model-value="allSelected"
+									@update:model-value="toggleSelectAll"
+									aria-label="Select all"
+								/>
+							</th>
+							<th
+								class="cursor-pointer select-none"
+								tabindex="0"
+								@click="handleSort( 'from_path' )"
+								@keydown="handleSortKeydown( $event, 'from_path' )"
+								:aria-sort="sort.field === 'from_path' ? ( sort.direction === 'asc' ? 'ascending' : 'descending' ) : undefined"
+							>
+								From{{ sortIndicator( 'from_path' ) }}
+							</th>
+							<th
+								class="cursor-pointer select-none"
+								tabindex="0"
+								@click="handleSort( 'to_path' )"
+								@keydown="handleSortKeydown( $event, 'to_path' )"
+								:aria-sort="sort.field === 'to_path' ? ( sort.direction === 'asc' ? 'ascending' : 'descending' ) : undefined"
+							>
+								To{{ sortIndicator( 'to_path' ) }}
+							</th>
+							<th
+								class="cursor-pointer select-none w-24"
+								tabindex="0"
+								@click="handleSort( 'status_code' )"
+								@keydown="handleSortKeydown( $event, 'status_code' )"
+								:aria-sort="sort.field === 'status_code' ? ( sort.direction === 'asc' ? 'ascending' : 'descending' ) : undefined"
+							>
+								Status{{ sortIndicator( 'status_code' ) }}
+							</th>
+							<th class="w-24">Type</th>
+							<th
+								class="cursor-pointer select-none w-20"
+								tabindex="0"
+								@click="handleSort( 'hits' )"
+								@keydown="handleSortKeydown( $event, 'hits' )"
+								:aria-sort="sort.field === 'hits' ? ( sort.direction === 'asc' ? 'ascending' : 'descending' ) : undefined"
+							>
+								Hits{{ sortIndicator( 'hits' ) }}
+							</th>
+							<th class="w-28"></th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr v-if="redirects.length === 0">
+							<td colspan="7" class="text-center text-base-content/50 py-8">
+								No redirects found.
+							</td>
+						</tr>
+						<tr v-for="redirect in redirects" :key="redirect.id">
+							<td>
+								<Checkbox
+									:model-value="selectedIds.has( redirect.id )"
+									@update:model-value="toggleSelect( redirect.id )"
+									:aria-label="`Select redirect ${ redirect.id }`"
+								/>
+							</td>
+							<td class="font-mono text-sm break-all">
+								{{ redirect.from_path }}
+								<Badge v-if="!redirect.is_active" color="warning" size="xs" class="ml-1">Inactive</Badge>
+							</td>
+							<td class="font-mono text-sm break-all">{{ redirect.to_path }}</td>
+							<td>
+								<Badge :color="redirect.is_permanent ? 'info' : 'warning'" size="sm">
+									{{ redirect.status_code }}
+								</Badge>
+							</td>
+							<td class="text-sm">{{ redirect.match_type_label }}</td>
+							<td class="text-sm">{{ redirect.hits }}</td>
+							<td>
+								<div class="flex gap-1">
+									<Button size="xs" @click="openEdit( redirect )" aria-label="Edit">Edit</Button>
+									<Button size="xs" color="error" @click="handleDelete( redirect.id )" :disabled="mutating" aria-label="Delete">Delete</Button>
+								</div>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+
+			<div v-if="meta && meta.last_page > 1" class="mt-4 flex justify-center">
+				<Pagination
+					:current-page="page"
+					:total-pages="meta.last_page"
+					@update:current-page="setPage"
+				/>
+			</div>
+		</template>
+
+		<!-- Create Modal -->
+		<Modal :open="showCreateModal" @update:open="closeModals" title="Create Redirect">
+			<div class="flex flex-col gap-4">
+				<Input v-model="formData.from_path" label="From Path" hint="The URL path to redirect from (e.g. /old-page)" :error="validationErrors.from_path?.[0]" required />
+				<Input v-model="formData.to_path" label="To Path" hint="The destination URL or path" :error="validationErrors.to_path?.[0]" required />
+				<div class="grid grid-cols-2 gap-4">
+					<Select v-model="formData.status_code" label="Status Code" :options="FORM_STATUS_OPTIONS" option-value="value" option-label="name" :error="validationErrors.status_code?.[0]" />
+					<Select v-model="formData.match_type" label="Match Type" :options="FORM_MATCH_OPTIONS" option-value="value" option-label="name" :error="validationErrors.match_type?.[0]" />
+				</div>
+				<Checkbox v-model="formData.is_active" label="Active" />
+				<Textarea v-model="formData.notes" label="Notes" :rows="2" :error="validationErrors.notes?.[0]" />
+			</div>
+
+			<template #actions>
+				<Button @click="closeModals">Cancel</Button>
+				<Button color="primary" @click="handleCreate" :disabled="mutating">
+					{{ mutating ? 'Creating...' : 'Create' }}
+				</Button>
+			</template>
+		</Modal>
+
+		<!-- Edit Modal -->
+		<Modal :open="editingRedirect !== null" @update:open="closeModals" title="Edit Redirect">
+			<div class="flex flex-col gap-4">
+				<Input v-model="formData.from_path" label="From Path" hint="The URL path to redirect from (e.g. /old-page)" :error="validationErrors.from_path?.[0]" required />
+				<Input v-model="formData.to_path" label="To Path" hint="The destination URL or path" :error="validationErrors.to_path?.[0]" required />
+				<div class="grid grid-cols-2 gap-4">
+					<Select v-model="formData.status_code" label="Status Code" :options="FORM_STATUS_OPTIONS" option-value="value" option-label="name" :error="validationErrors.status_code?.[0]" />
+					<Select v-model="formData.match_type" label="Match Type" :options="FORM_MATCH_OPTIONS" option-value="value" option-label="name" :error="validationErrors.match_type?.[0]" />
+				</div>
+				<Checkbox v-model="formData.is_active" label="Active" />
+				<Textarea v-model="formData.notes" label="Notes" :rows="2" :error="validationErrors.notes?.[0]" />
+			</div>
+
+			<template #actions>
+				<Button @click="closeModals">Cancel</Button>
+				<Button color="primary" @click="handleUpdate" :disabled="mutating">
+					{{ mutating ? 'Saving...' : 'Save Changes' }}
+				</Button>
+			</template>
+		</Modal>
+	</div>
+</template>

--- a/resources/js/vue/components/admin/SchemaTab.vue
+++ b/resources/js/vue/components/admin/SchemaTab.vue
@@ -11,7 +11,7 @@
 -->
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 
 import { Alert, Input, Loading, Select, Textarea } from '@artisanpack-ui/vue';
 
@@ -156,7 +156,7 @@ const emit = defineEmits<{
 }>();
 
 const api              = useApi( props.apiOptions );
-const encodedModelType = encodeURIComponent( props.modelType );
+const encodedModelType = computed( () => encodeURIComponent( props.modelType ) );
 const schemaData       = ref<SchemaResponse | null>( null );
 const loadingSchema    = ref( true );
 const schemaError      = ref<string | null>( null );
@@ -181,7 +181,7 @@ async function fetchSchema(): Promise<void> {
 
 	try {
 		const response = await api.get<{ data: SchemaResponse }>(
-			`/schema/${ encodedModelType }/${ props.modelId }`,
+			`/schema/${ encodedModelType.value }/${ props.modelId }`,
 		);
 
 		if ( currentRequestId === requestId ) {
@@ -227,6 +227,8 @@ function handleNumberInput( key: string, rawValue: string ): void {
 }
 
 onMounted( fetchSchema );
+
+watch( () => [props.modelType, props.modelId], fetchSchema );
 </script>
 
 <template>

--- a/resources/js/vue/components/admin/SchemaTab.vue
+++ b/resources/js/vue/components/admin/SchemaTab.vue
@@ -1,0 +1,281 @@
+<!--
+  SchemaTab component.
+
+  Tab for configuring Schema.org structured data with a schema
+  type selector and dynamic form fields based on the selected type.
+
+  @package    ArtisanPack_UI
+  @subpackage SEO
+
+  @since      1.1.0
+-->
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+
+import { Alert, Input, Loading, Select, Textarea } from '@artisanpack-ui/vue';
+
+import type { UseApiOptions } from '../../composables/useApi';
+import { useApi } from '../../composables/useApi';
+
+import type { SchemaResponse, SchemaType } from '../../../types/schema';
+import type { SeoMetaResponse } from '../../../types/seo-data';
+
+interface SchemaFieldDef {
+	key: string;
+	label: string;
+	type: 'text' | 'textarea' | 'url' | 'number' | 'date';
+}
+
+const SCHEMA_FIELDS: Record<string, SchemaFieldDef[]> = {
+	Article: [
+		{ key: 'headline', label: 'Headline', type: 'text' },
+		{ key: 'description', label: 'Description', type: 'textarea' },
+		{ key: 'url', label: 'URL', type: 'url' },
+		{ key: 'image', label: 'Image URL', type: 'url' },
+		{ key: 'datePublished', label: 'Date Published', type: 'date' },
+		{ key: 'dateModified', label: 'Date Modified', type: 'date' },
+		{ key: 'keywords', label: 'Keywords', type: 'text' },
+		{ key: 'articleSection', label: 'Article Section', type: 'text' },
+		{ key: 'wordCount', label: 'Word Count', type: 'number' },
+		{ key: 'inLanguage', label: 'Language', type: 'text' },
+	],
+	BlogPosting: [
+		{ key: 'headline', label: 'Headline', type: 'text' },
+		{ key: 'description', label: 'Description', type: 'textarea' },
+		{ key: 'url', label: 'URL', type: 'url' },
+		{ key: 'image', label: 'Image URL', type: 'url' },
+		{ key: 'datePublished', label: 'Date Published', type: 'date' },
+		{ key: 'dateModified', label: 'Date Modified', type: 'date' },
+		{ key: 'keywords', label: 'Keywords', type: 'text' },
+		{ key: 'wordCount', label: 'Word Count', type: 'number' },
+	],
+	Product: [
+		{ key: 'name', label: 'Name', type: 'text' },
+		{ key: 'description', label: 'Description', type: 'textarea' },
+		{ key: 'image', label: 'Image URL', type: 'url' },
+		{ key: 'url', label: 'URL', type: 'url' },
+		{ key: 'sku', label: 'SKU', type: 'text' },
+		{ key: 'gtin', label: 'GTIN', type: 'text' },
+		{ key: 'mpn', label: 'MPN', type: 'text' },
+		{ key: 'brand', label: 'Brand', type: 'text' },
+		{ key: 'category', label: 'Category', type: 'text' },
+		{ key: 'color', label: 'Color', type: 'text' },
+		{ key: 'material', label: 'Material', type: 'text' },
+	],
+	Event: [
+		{ key: 'name', label: 'Event Name', type: 'text' },
+		{ key: 'description', label: 'Description', type: 'textarea' },
+		{ key: 'url', label: 'URL', type: 'url' },
+		{ key: 'image', label: 'Image URL', type: 'url' },
+		{ key: 'startDate', label: 'Start Date', type: 'date' },
+		{ key: 'endDate', label: 'End Date', type: 'date' },
+		{ key: 'virtualLocation', label: 'Virtual Location URL', type: 'url' },
+		{ key: 'eventStatus', label: 'Event Status', type: 'text' },
+		{ key: 'eventAttendanceMode', label: 'Attendance Mode', type: 'text' },
+	],
+	Organization: [
+		{ key: 'name', label: 'Name', type: 'text' },
+		{ key: 'url', label: 'URL', type: 'url' },
+		{ key: 'logo', label: 'Logo URL', type: 'url' },
+		{ key: 'email', label: 'Email', type: 'text' },
+		{ key: 'phone', label: 'Phone', type: 'text' },
+		{ key: 'description', label: 'Description', type: 'textarea' },
+	],
+	LocalBusiness: [
+		{ key: 'name', label: 'Business Name', type: 'text' },
+		{ key: 'url', label: 'URL', type: 'url' },
+		{ key: 'logo', label: 'Logo URL', type: 'url' },
+		{ key: 'email', label: 'Email', type: 'text' },
+		{ key: 'phone', label: 'Phone', type: 'text' },
+		{ key: 'description', label: 'Description', type: 'textarea' },
+		{ key: 'priceRange', label: 'Price Range', type: 'text' },
+		{ key: 'areaServed', label: 'Area Served', type: 'text' },
+		{ key: 'paymentAccepted', label: 'Payment Accepted', type: 'text' },
+		{ key: 'currenciesAccepted', label: 'Currencies Accepted', type: 'text' },
+	],
+	WebSite: [
+		{ key: 'name', label: 'Site Name', type: 'text' },
+		{ key: 'url', label: 'URL', type: 'url' },
+		{ key: 'description', label: 'Description', type: 'textarea' },
+		{ key: 'searchUrl', label: 'Search URL', type: 'url' },
+		{ key: 'alternateName', label: 'Alternate Name', type: 'text' },
+		{ key: 'inLanguage', label: 'Language', type: 'text' },
+	],
+	WebPage: [
+		{ key: 'name', label: 'Page Name', type: 'text' },
+		{ key: 'url', label: 'URL', type: 'url' },
+		{ key: 'description', label: 'Description', type: 'textarea' },
+		{ key: 'datePublished', label: 'Date Published', type: 'date' },
+		{ key: 'dateModified', label: 'Date Modified', type: 'date' },
+		{ key: 'image', label: 'Image URL', type: 'url' },
+		{ key: 'isPartOf', label: 'Is Part Of', type: 'url' },
+		{ key: 'inLanguage', label: 'Language', type: 'text' },
+	],
+	Service: [
+		{ key: 'name', label: 'Service Name', type: 'text' },
+		{ key: 'description', label: 'Description', type: 'textarea' },
+		{ key: 'url', label: 'URL', type: 'url' },
+		{ key: 'image', label: 'Image URL', type: 'url' },
+		{ key: 'serviceType', label: 'Service Type', type: 'text' },
+		{ key: 'category', label: 'Category', type: 'text' },
+		{ key: 'areaServed', label: 'Area Served', type: 'text' },
+		{ key: 'brand', label: 'Brand', type: 'text' },
+	],
+	FAQPage: [
+		{ key: 'name', label: 'Page Name', type: 'text' },
+		{ key: 'description', label: 'Description', type: 'textarea' },
+		{ key: 'url', label: 'URL', type: 'url' },
+	],
+	Review: [
+		{ key: 'name', label: 'Review Title', type: 'text' },
+		{ key: 'reviewBody', label: 'Review Body', type: 'textarea' },
+		{ key: 'datePublished', label: 'Date Published', type: 'date' },
+	],
+	AggregateRating: [
+		{ key: 'ratingValue', label: 'Rating Value', type: 'number' },
+		{ key: 'bestRating', label: 'Best Rating', type: 'number' },
+		{ key: 'worstRating', label: 'Worst Rating', type: 'number' },
+		{ key: 'ratingCount', label: 'Rating Count', type: 'number' },
+		{ key: 'reviewCount', label: 'Review Count', type: 'number' },
+	],
+	BreadcrumbList: [],
+};
+
+const props = defineProps<{
+	data: SeoMetaResponse;
+	apiOptions: UseApiOptions;
+	modelType: string;
+	modelId: number;
+	errors?: Record<string, string[]>;
+}>();
+
+const emit = defineEmits<{
+	'schema-type-change': [schemaType: string | null];
+	'schema-markup-change': [markup: Record<string, unknown>];
+}>();
+
+const api              = useApi( props.apiOptions );
+const encodedModelType = encodeURIComponent( props.modelType );
+const schemaData       = ref<SchemaResponse | null>( null );
+const loadingSchema    = ref( true );
+const schemaError      = ref<string | null>( null );
+let requestId          = 0;
+
+const selectedType  = computed( () => ( props.data.schema_type as SchemaType | null ) );
+const markup        = computed( () => ( props.data.schema_markup ?? {} ) as Record<string, unknown> );
+const fields        = computed( () => selectedType.value ? ( SCHEMA_FIELDS[selectedType.value] ?? [] ) : [] );
+const availableTypes = computed( () => schemaData.value?.available_types ?? Object.keys( SCHEMA_FIELDS ) as SchemaType[] );
+
+const typeOptions = computed( () => [
+	{ value: '', name: 'None' },
+	...availableTypes.value.map( ( type ) => ( { value: type, name: type } ) ),
+] );
+
+async function fetchSchema(): Promise<void> {
+	requestId += 1;
+	const currentRequestId = requestId;
+
+	loadingSchema.value = true;
+	schemaError.value   = null;
+
+	try {
+		const response = await api.get<{ data: SchemaResponse }>(
+			`/schema/${ encodedModelType }/${ props.modelId }`,
+		);
+
+		if ( currentRequestId === requestId ) {
+			schemaData.value = response.data;
+		}
+	} catch {
+		if ( currentRequestId === requestId ) {
+			schemaError.value = 'Failed to load schema data.';
+		}
+	} finally {
+		if ( currentRequestId === requestId ) {
+			loadingSchema.value = false;
+		}
+	}
+}
+
+function handleTypeChange( value: string ): void {
+	const type = value || null;
+	emit( 'schema-type-change', type );
+	emit( 'schema-markup-change', {} );
+}
+
+function handleFieldChange( key: string, value: unknown ): void {
+	const updated = { ...markup.value, [key]: value };
+	emit( 'schema-markup-change', updated );
+}
+
+function handleNumberInput( key: string, rawValue: string ): void {
+	if ( '' === rawValue ) {
+		handleFieldChange( key, '' );
+
+		return;
+	}
+
+	const isComplete = /^-?\d+(\.\d+)?$/.test( rawValue );
+
+	if ( isComplete ) {
+		const parsed = Number( rawValue );
+		handleFieldChange( key, Number.isFinite( parsed ) ? parsed : rawValue );
+	} else {
+		handleFieldChange( key, rawValue );
+	}
+}
+
+onMounted( fetchSchema );
+</script>
+
+<template>
+	<Loading v-if="loadingSchema" />
+
+	<Alert v-else-if="schemaError" color="error">{{ schemaError }}</Alert>
+
+	<div v-else class="flex flex-col gap-4">
+		<Select
+			label="Schema Type"
+			:model-value="selectedType ?? ''"
+			@update:model-value="handleTypeChange"
+			:options="typeOptions"
+			option-value="value"
+			option-label="name"
+			:error="errors?.schema_type?.[0]"
+		/>
+
+		<Alert v-if="selectedType && fields.length === 0" color="info">
+			This schema type uses automatic data. No additional fields needed.
+		</Alert>
+
+		<template v-if="selectedType">
+			<template v-for="field in fields" :key="field.key">
+				<Textarea
+					v-if="field.type === 'textarea'"
+					:label="field.label"
+					:model-value="String( ( markup[field.key] as string | number ) ?? '' )"
+					@update:model-value="handleFieldChange( field.key, $event )"
+					:error="errors?.[`schema_markup.${ field.key }`]?.[0]"
+					:rows="3"
+				/>
+
+				<Input
+					v-else
+					:label="field.label"
+					:model-value="String( ( markup[field.key] as string | number ) ?? '' )"
+					@update:model-value="field.type === 'number' ? handleNumberInput( field.key, String( $event ) ) : handleFieldChange( field.key, $event )"
+					:type="field.type"
+					:error="errors?.[`schema_markup.${ field.key }`]?.[0]"
+				/>
+			</template>
+		</template>
+
+		<div v-if="schemaData?.generated" class="mt-2">
+			<label class="label">
+				<span class="label-text font-semibold">Generated JSON-LD Preview</span>
+			</label>
+			<pre class="bg-base-200 rounded-lg p-4 text-xs overflow-x-auto max-h-64">{{ JSON.stringify( schemaData.generated, null, 2 ) }}</pre>
+		</div>
+	</div>
+</template>

--- a/resources/js/vue/components/admin/SeoAnalysisPanel.vue
+++ b/resources/js/vue/components/admin/SeoAnalysisPanel.vue
@@ -1,0 +1,250 @@
+<!--
+  SeoAnalysisPanel component.
+
+  Displays real-time SEO content analysis results with per-analyzer
+  scores, overall score, grade, and actionable recommendations.
+
+  @package    ArtisanPack_UI
+  @subpackage SEO
+
+  @since      1.1.0
+-->
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+import { Alert, Badge, Button, Card, Collapse, Input, Loading, Progress } from '@artisanpack-ui/vue';
+
+import { useSeoAnalysis } from '../../composables/useSeoAnalysis';
+
+import type { UseApiOptions } from '../../composables/useApi';
+import type { AnalysisGradeColor, AnalyzerName } from '../../../types/analysis';
+
+const GRADE_COLOR_MAP: Record<AnalysisGradeColor, 'success' | 'warning' | 'error'> = {
+	green: 'success',
+	yellow: 'warning',
+	red: 'error',
+};
+
+const ANALYZER_LABELS: Record<AnalyzerName, string> = {
+	content_length: 'Content Length',
+	focus_keyword: 'Focus Keyword',
+	heading_structure: 'Heading Structure',
+	image_alt: 'Image Alt Text',
+	internal_links: 'Internal Links',
+	keyword_density: 'Keyword Density',
+	meta_length: 'Meta Tag Length',
+	readability: 'Readability',
+};
+
+const props = withDefaults( defineProps<UseApiOptions & {
+	modelType: string;
+	modelId: number;
+	focusKeyword?: string;
+	debounceMs?: number;
+	className?: string;
+}>(), {
+	csrfToken: undefined,
+	authorization: undefined,
+	credentials: undefined,
+	focusKeyword: undefined,
+	debounceMs: undefined,
+	className: undefined,
+} );
+
+const emit = defineEmits<{
+	'update:focusKeyword': [value: string];
+}>();
+
+const {
+	result,
+	analyzing,
+	loading,
+	error,
+	analyze,
+} = useSeoAnalysis( {
+	baseUrl: props.baseUrl,
+	csrfToken: props.csrfToken,
+	authorization: props.authorization,
+	credentials: props.credentials,
+	modelType: props.modelType,
+	modelId: props.modelId,
+	debounceMs: props.debounceMs,
+} );
+
+const gradeColor = computed( () => result.value ? GRADE_COLOR_MAP[result.value.grade_color] : 'info' );
+const scoreColor = computed( () => {
+	if ( !result.value ) {
+		return 'error';
+	}
+
+	return result.value.overall_score >= 70 ? 'success' : ( result.value.overall_score >= 40 ? 'warning' : 'error' );
+} );
+
+const analyzerEntries = computed( () => {
+	if ( !result.value?.analyzer_results ) {
+		return [];
+	}
+
+	return Object.entries( result.value.analyzer_results ) as [AnalyzerName, Record<string, unknown>][];
+} );
+
+function handleAnalyze(): void {
+	analyze( props.focusKeyword );
+}
+
+function getAnalyzerLabel( name: AnalyzerName ): string {
+	return ANALYZER_LABELS[name] ?? name;
+}
+
+function getAnalyzerScore( item: Record<string, unknown> ): number {
+	return ( item.score as number ) ?? 0;
+}
+
+function getAnalyzerStatus( item: Record<string, unknown> ): string {
+	const score = getAnalyzerScore( item );
+
+	return score >= 70 ? 'pass' : ( score >= 40 ? 'warning' : 'fail' );
+}
+
+function getAnalyzerStatusColor( item: Record<string, unknown> ): 'success' | 'warning' | 'error' {
+	const score = getAnalyzerScore( item );
+
+	return score >= 70 ? 'success' : ( score >= 40 ? 'warning' : 'error' );
+}
+
+function getAnalyzerDetails( item: Record<string, unknown> ): string[] {
+	return Object.entries( item )
+		.filter( ( [key] ) => 'score' !== key )
+		.map( ( [key, value] ) => `${ key.replace( /_/g, ' ' ) }: ${ value }` );
+}
+
+function getScoreColor( score: number ): 'success' | 'warning' | 'error' {
+	return score >= 70 ? 'success' : ( score >= 40 ? 'warning' : 'error' );
+}
+</script>
+
+<template>
+	<Card :class="className">
+		<div class="p-4 flex flex-col gap-4">
+			<div class="flex items-center justify-between">
+				<h3 class="font-semibold text-lg">SEO Analysis</h3>
+				<Button size="sm" color="primary" @click="handleAnalyze" :disabled="analyzing">
+					{{ analyzing ? 'Analyzing...' : 'Run Analysis' }}
+				</Button>
+			</div>
+
+			<Alert v-if="error" color="error">{{ error }}</Alert>
+
+			<Input
+				v-if="focusKeyword !== undefined"
+				label="Focus Keyword"
+				:model-value="focusKeyword ?? ''"
+				@update:model-value="emit( 'update:focusKeyword', String( $event ) )"
+				hint="The primary keyword to analyze against"
+			/>
+
+			<Loading v-if="loading && !result" />
+
+			<p v-else-if="!result && !error" class="text-sm text-base-content/60">
+				No analysis results yet. Click "Run Analysis" to analyze your content.
+			</p>
+
+			<template v-if="result">
+				<!-- Overall score -->
+				<div class="flex items-center gap-4">
+					<div
+						class="radial-progress"
+						:class="`text-${ scoreColor }`"
+						:style="{ '--value': result.overall_score, '--size': '5rem', '--thickness': '0.5rem' }"
+						role="progressbar"
+					>
+						<span class="text-lg font-bold">{{ result.overall_score }}</span>
+					</div>
+
+					<div>
+						<Badge :color="gradeColor" size="lg">{{ result.grade_label }}</Badge>
+						<p v-if="result.word_count > 0" class="text-sm text-base-content/60 mt-1">
+							{{ result.word_count }} words
+						</p>
+					</div>
+				</div>
+
+				<!-- Category scores -->
+				<div class="flex flex-col gap-2">
+					<div class="flex items-center gap-2">
+						<span class="text-sm w-24">Readability</span>
+						<Progress :value="result.scores.readability" :max="100" :color="getScoreColor( result.scores.readability )" class="flex-1" />
+						<span class="text-sm font-mono w-8 text-right">{{ result.scores.readability }}</span>
+					</div>
+					<div class="flex items-center gap-2">
+						<span class="text-sm w-24">Keyword</span>
+						<Progress :value="result.scores.keyword" :max="100" :color="getScoreColor( result.scores.keyword )" class="flex-1" />
+						<span class="text-sm font-mono w-8 text-right">{{ result.scores.keyword }}</span>
+					</div>
+					<div class="flex items-center gap-2">
+						<span class="text-sm w-24">Meta Tags</span>
+						<Progress :value="result.scores.meta" :max="100" :color="getScoreColor( result.scores.meta )" class="flex-1" />
+						<span class="text-sm font-mono w-8 text-right">{{ result.scores.meta }}</span>
+					</div>
+					<div class="flex items-center gap-2">
+						<span class="text-sm w-24">Content</span>
+						<Progress :value="result.scores.content" :max="100" :color="getScoreColor( result.scores.content )" class="flex-1" />
+						<span class="text-sm font-mono w-8 text-right">{{ result.scores.content }}</span>
+					</div>
+				</div>
+
+				<!-- Issues -->
+				<div v-if="result.issue_count > 0">
+					<h4 class="font-medium text-sm mb-2 text-error">Issues ({{ result.issue_count }})</h4>
+					<ul class="list-disc list-inside text-sm space-y-1">
+						<li v-for="( issue, i ) in result.issues" :key="i">{{ issue.message }}</li>
+					</ul>
+				</div>
+
+				<!-- Suggestions -->
+				<div v-if="result.suggestion_count > 0">
+					<h4 class="font-medium text-sm mb-2 text-warning">Suggestions ({{ result.suggestion_count }})</h4>
+					<ul class="list-disc list-inside text-sm space-y-1">
+						<li v-for="( sug, i ) in result.suggestions" :key="i">{{ sug.message }}</li>
+					</ul>
+				</div>
+
+				<!-- Passed -->
+				<div v-if="result.passed_count > 0">
+					<h4 class="font-medium text-sm mb-2 text-success">Passed ({{ result.passed_count }})</h4>
+					<ul class="list-disc list-inside text-sm space-y-1">
+						<li v-for="( check, i ) in result.passed_checks" :key="i">{{ check }}</li>
+					</ul>
+				</div>
+
+				<!-- Per-analyzer results -->
+				<div v-if="analyzerEntries.length > 0">
+					<h4 class="font-medium text-sm mb-2">Detailed Results</h4>
+					<div class="flex flex-col gap-1">
+						<Collapse
+							v-for="[name, analyzerResult] in analyzerEntries"
+							:key="name"
+							:title="`${ getAnalyzerLabel( name ) } — ${ getAnalyzerScore( analyzerResult ) }/100`"
+						>
+							<template #title>
+								<div class="flex items-center gap-2">
+									<Badge :color="getAnalyzerStatusColor( analyzerResult )" size="xs">
+										{{ getAnalyzerStatus( analyzerResult ) }}
+									</Badge>
+									<span>{{ getAnalyzerLabel( name ) }}</span>
+									<span class="text-xs text-base-content/50 ml-auto">{{ getAnalyzerScore( analyzerResult ) }}/100</span>
+								</div>
+							</template>
+
+							<ul v-if="getAnalyzerDetails( analyzerResult ).length > 0" class="list-disc list-inside text-sm space-y-1">
+								<li v-for="( detail, i ) in getAnalyzerDetails( analyzerResult )" :key="i">{{ detail }}</li>
+							</ul>
+							<p v-else class="text-sm text-success">All checks passed.</p>
+						</Collapse>
+					</div>
+				</div>
+			</template>
+		</div>
+	</Card>
+</template>

--- a/resources/js/vue/components/admin/SeoDashboard.vue
+++ b/resources/js/vue/components/admin/SeoDashboard.vue
@@ -54,8 +54,12 @@ const analysisScore  = ref<number | null>( null );
 const analysisGrade  = ref<string | null>( null );
 const isLoading      = ref( true );
 const error          = ref<string | null>( null );
+let latestRequestId  = 0;
 
 async function fetchDashboardData(): Promise<void> {
+	latestRequestId += 1;
+	const currentRequestId = latestRequestId;
+
 	isLoading.value = true;
 	error.value     = null;
 
@@ -65,9 +69,17 @@ async function fetchDashboardData(): Promise<void> {
 			meta: { total: number };
 		}>( '/redirects', { per_page: '5', sort_by: 'created_at', sort_order: 'desc' } );
 
+		if ( currentRequestId !== latestRequestId ) {
+			return;
+		}
+
 		const activeResponse = await api.get<{
 			meta: { total: number };
 		}>( '/redirects', { per_page: '1', is_active: '1' } );
+
+		if ( currentRequestId !== latestRequestId ) {
+			return;
+		}
 
 		const totalRedirects  = recentResponse.meta?.total ?? recentResponse.data.length;
 		const activeRedirects = activeResponse.meta?.total ?? 0;
@@ -81,7 +93,6 @@ async function fetchDashboardData(): Promise<void> {
 			recentRedirects,
 		};
 
-		// Reset analysis state
 		analysisScore.value = null;
 		analysisGrade.value = null;
 
@@ -91,17 +102,25 @@ async function fetchDashboardData(): Promise<void> {
 					data: { overall_score: number; grade_label: string };
 				}>( `/analysis/${ encodedModelType.value }/${ props.modelId }` );
 
-				analysisScore.value = analysisResponse.data.overall_score;
-				analysisGrade.value = analysisResponse.data.grade_label;
+				if ( currentRequestId === latestRequestId ) {
+					analysisScore.value = analysisResponse.data.overall_score;
+					analysisGrade.value = analysisResponse.data.grade_label;
+				}
 			} catch {
-				analysisScore.value = null;
-				analysisGrade.value = null;
+				if ( currentRequestId === latestRequestId ) {
+					analysisScore.value = null;
+					analysisGrade.value = null;
+				}
 			}
 		}
 	} catch ( err ) {
-		error.value = err instanceof Error ? err.message : 'Failed to load dashboard data.';
+		if ( currentRequestId === latestRequestId ) {
+			error.value = err instanceof Error ? err.message : 'Failed to load dashboard data.';
+		}
 	} finally {
-		isLoading.value = false;
+		if ( currentRequestId === latestRequestId ) {
+			isLoading.value = false;
+		}
 	}
 }
 

--- a/resources/js/vue/components/admin/SeoDashboard.vue
+++ b/resources/js/vue/components/admin/SeoDashboard.vue
@@ -11,7 +11,7 @@
 -->
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 
 import { Alert, Badge, Card, Loading, Stat } from '@artisanpack-ui/vue';
 
@@ -47,7 +47,7 @@ const api = useApi( {
 	credentials: props.credentials,
 } );
 
-const encodedModelType = props.modelType ? encodeURIComponent( props.modelType ) : null;
+const encodedModelType = computed( () => props.modelType ? encodeURIComponent( props.modelType ) : null );
 
 const stats          = ref<DashboardStats | null>( null );
 const analysisScore  = ref<number | null>( null );
@@ -85,11 +85,11 @@ async function fetchDashboardData(): Promise<void> {
 		analysisScore.value = null;
 		analysisGrade.value = null;
 
-		if ( encodedModelType && props.modelId ) {
+		if ( encodedModelType.value && props.modelId ) {
 			try {
 				const analysisResponse = await api.get<{
 					data: { overall_score: number; grade_label: string };
-				}>( `/analysis/${ encodedModelType }/${ props.modelId }` );
+				}>( `/analysis/${ encodedModelType.value }/${ props.modelId }` );
 
 				analysisScore.value = analysisResponse.data.overall_score;
 				analysisGrade.value = analysisResponse.data.grade_label;
@@ -106,6 +106,8 @@ async function fetchDashboardData(): Promise<void> {
 }
 
 onMounted( fetchDashboardData );
+
+watch( () => [props.modelType, props.modelId], fetchDashboardData );
 </script>
 
 <template>

--- a/resources/js/vue/components/admin/SeoDashboard.vue
+++ b/resources/js/vue/components/admin/SeoDashboard.vue
@@ -1,0 +1,163 @@
+<!--
+  SeoDashboard component.
+
+  Overview dashboard displaying quick SEO stats, recent analysis
+  scores, and redirect statistics.
+
+  @package    ArtisanPack_UI
+  @subpackage SEO
+
+  @since      1.1.0
+-->
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+
+import { Alert, Badge, Card, Loading, Stat } from '@artisanpack-ui/vue';
+
+import type { UseApiOptions } from '../../composables/useApi';
+import { useApi } from '../../composables/useApi';
+
+import type { Redirect } from '../../../types/redirect';
+
+interface DashboardStats {
+	totalRedirects: number;
+	activeRedirects: number;
+	totalHits: number;
+	recentRedirects: Redirect[];
+}
+
+const props = withDefaults( defineProps<UseApiOptions & {
+	modelType?: string;
+	modelId?: number;
+	className?: string;
+}>(), {
+	csrfToken: undefined,
+	authorization: undefined,
+	credentials: undefined,
+	modelType: undefined,
+	modelId: undefined,
+	className: undefined,
+} );
+
+const api = useApi( {
+	baseUrl: props.baseUrl,
+	csrfToken: props.csrfToken,
+	authorization: props.authorization,
+	credentials: props.credentials,
+} );
+
+const encodedModelType = props.modelType ? encodeURIComponent( props.modelType ) : null;
+
+const stats          = ref<DashboardStats | null>( null );
+const analysisScore  = ref<number | null>( null );
+const analysisGrade  = ref<string | null>( null );
+const isLoading      = ref( true );
+const error          = ref<string | null>( null );
+
+async function fetchDashboardData(): Promise<void> {
+	isLoading.value = true;
+	error.value     = null;
+
+	try {
+		const recentResponse = await api.get<{
+			data: Redirect[];
+			meta: { total: number };
+		}>( '/redirects', { per_page: '5', sort_by: 'created_at', sort_order: 'desc' } );
+
+		const activeResponse = await api.get<{
+			meta: { total: number };
+		}>( '/redirects', { per_page: '1', is_active: '1' } );
+
+		const totalRedirects  = recentResponse.meta?.total ?? recentResponse.data.length;
+		const activeRedirects = activeResponse.meta?.total ?? 0;
+		const recentRedirects = recentResponse.data;
+		const recentHits      = recentRedirects.reduce( ( sum, r ) => sum + r.hits, 0 );
+
+		stats.value = {
+			totalRedirects,
+			activeRedirects,
+			totalHits: recentHits,
+			recentRedirects,
+		};
+
+		// Reset analysis state
+		analysisScore.value = null;
+		analysisGrade.value = null;
+
+		if ( encodedModelType && props.modelId ) {
+			try {
+				const analysisResponse = await api.get<{
+					data: { overall_score: number; grade_label: string };
+				}>( `/analysis/${ encodedModelType }/${ props.modelId }` );
+
+				analysisScore.value = analysisResponse.data.overall_score;
+				analysisGrade.value = analysisResponse.data.grade_label;
+			} catch {
+				analysisScore.value = null;
+				analysisGrade.value = null;
+			}
+		}
+	} catch ( err ) {
+		error.value = err instanceof Error ? err.message : 'Failed to load dashboard data.';
+	} finally {
+		isLoading.value = false;
+	}
+}
+
+onMounted( fetchDashboardData );
+</script>
+
+<template>
+	<div :class="className">
+		<Loading v-if="isLoading" />
+
+		<Alert v-else-if="error" color="error">{{ error }}</Alert>
+
+		<template v-else>
+			<!-- Stats Row -->
+			<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+				<Stat title="Total Redirects" :value="String( stats?.totalRedirects ?? 0 )" />
+				<Stat title="Active Redirects" :value="String( stats?.activeRedirects ?? 0 )" />
+				<Stat title="Recent Hits" :value="String( stats?.totalHits ?? 0 )" description="From latest 5 redirects" />
+				<Stat v-if="analysisScore !== null" title="SEO Score" :value="String( analysisScore )" :description="analysisGrade ?? undefined" />
+			</div>
+
+			<!-- Recent Redirects -->
+			<Card>
+				<div class="p-4">
+					<h3 class="font-semibold text-lg mb-3">Recent Redirects</h3>
+
+					<p v-if="( stats?.recentRedirects.length ?? 0 ) === 0" class="text-base-content/60 text-sm">
+						No redirects yet.
+					</p>
+
+					<div v-else class="overflow-x-auto">
+						<table class="table table-sm w-full">
+							<thead>
+								<tr>
+									<th>From</th>
+									<th>To</th>
+									<th>Status</th>
+									<th>Hits</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr v-for="redirect in stats?.recentRedirects" :key="redirect.id">
+									<td class="font-mono text-xs">{{ redirect.from_path }}</td>
+									<td class="font-mono text-xs">{{ redirect.to_path }}</td>
+									<td>
+										<Badge :color="redirect.is_permanent ? 'info' : 'warning'" size="xs">
+											{{ redirect.status_code }}
+										</Badge>
+									</td>
+									<td>{{ redirect.hits }}</td>
+								</tr>
+							</tbody>
+						</table>
+					</div>
+				</div>
+			</Card>
+		</template>
+	</div>
+</template>

--- a/resources/js/vue/components/admin/SeoMetaEditor.vue
+++ b/resources/js/vue/components/admin/SeoMetaEditor.vue
@@ -1,0 +1,203 @@
+<!--
+  SeoMetaEditor component.
+
+  Main tabbed editor for all SEO metadata including basic meta,
+  Open Graph, Twitter Card, Schema.org, hreflang, and sitemap settings.
+
+  @package    ArtisanPack_UI
+  @subpackage SEO
+
+  @since      1.1.0
+-->
+
+<script setup lang="ts">
+import { computed, reactive, ref } from 'vue';
+
+import { Alert, Button, Loading, Tabs } from '@artisanpack-ui/vue';
+
+import type { UseApiOptions } from '../../composables/useApi';
+import { useSeoMeta } from '../../composables/useSeoMeta';
+
+import type { SeoMetaResponse } from '../../../types/seo-data';
+import type { HreflangEntry } from '../../../types/hreflang';
+
+import BasicMetaTab from './BasicMetaTab.vue';
+import HreflangTab from './HreflangTab.vue';
+import OpenGraphTab from './OpenGraphTab.vue';
+import SchemaTab from './SchemaTab.vue';
+import SitemapTab from './SitemapTab.vue';
+import TwitterCardTab from './TwitterCardTab.vue';
+
+const props = withDefaults( defineProps<UseApiOptions & {
+	modelType: string;
+	modelId: number;
+	initialData?: SeoMetaResponse;
+	className?: string;
+}>(), {
+	csrfToken: undefined,
+	authorization: undefined,
+	credentials: undefined,
+	initialData: undefined,
+	className: undefined,
+} );
+
+const emit = defineEmits<{
+	'save': [data: SeoMetaResponse];
+}>();
+
+const {
+	data,
+	loading,
+	saving,
+	error,
+	validationErrors,
+	updateMeta,
+} = useSeoMeta( {
+	baseUrl: props.baseUrl,
+	csrfToken: props.csrfToken,
+	authorization: props.authorization,
+	credentials: props.credentials,
+	modelType: props.modelType,
+	modelId: props.modelId,
+	initialData: props.initialData,
+} );
+
+const pendingChanges = reactive<Record<string, unknown>>( {} );
+const dirty          = ref( false );
+
+const apiOptions = computed<UseApiOptions>( () => ( {
+	baseUrl: props.baseUrl,
+	csrfToken: props.csrfToken,
+	authorization: props.authorization,
+	credentials: props.credentials,
+} ) );
+
+const displayData = computed<SeoMetaResponse | null>( () => {
+	if ( !data.value ) {
+		return null;
+	}
+
+	return { ...data.value, ...pendingChanges } as SeoMetaResponse;
+} );
+
+function handleFieldChange( field: string, value: unknown ): void {
+	pendingChanges[field] = value;
+	dirty.value           = true;
+}
+
+function handleHreflangChange( entries: HreflangEntry[] ): void {
+	pendingChanges.hreflang = entries;
+	dirty.value             = true;
+}
+
+function handleSchemaTypeChange( schemaType: string | null ): void {
+	pendingChanges.schema_type = schemaType;
+	dirty.value                = true;
+}
+
+function handleSchemaMarkupChange( markup: Record<string, unknown> ): void {
+	pendingChanges.schema_markup = markup;
+	dirty.value                  = true;
+}
+
+async function handleSave(): Promise<void> {
+	const result = await updateMeta( { ...pendingChanges } );
+
+	if ( result ) {
+		Object.keys( pendingChanges ).forEach( ( key ) => delete pendingChanges[key] );
+		dirty.value = false;
+		emit( 'save', result );
+	}
+}
+
+const tabs = [
+	{ name: 'basic', label: 'Basic SEO' },
+	{ name: 'opengraph', label: 'Open Graph' },
+	{ name: 'twitter', label: 'Twitter Card' },
+	{ name: 'schema', label: 'Schema' },
+	{ name: 'hreflang', label: 'Hreflang' },
+	{ name: 'sitemap', label: 'Sitemap' },
+];
+</script>
+
+<template>
+	<div :class="className">
+		<Loading v-if="loading" />
+
+		<Alert v-else-if="!data" color="error">
+			{{ error ?? 'Failed to load SEO data.' }}
+		</Alert>
+
+		<template v-else-if="displayData">
+			<Alert v-if="error" color="error" class="mb-4">
+				{{ error }}
+			</Alert>
+
+			<Tabs :tabs="tabs" variant="bordered">
+				<template #basic>
+					<BasicMetaTab
+						:data="displayData"
+						:errors="validationErrors"
+						@change="handleFieldChange"
+					/>
+				</template>
+
+				<template #opengraph>
+					<OpenGraphTab
+						:data="displayData"
+						:errors="validationErrors"
+						@change="handleFieldChange"
+					/>
+				</template>
+
+				<template #twitter>
+					<TwitterCardTab
+						:data="displayData"
+						:errors="validationErrors"
+						@change="handleFieldChange"
+					/>
+				</template>
+
+				<template #schema>
+					<SchemaTab
+						:data="displayData"
+						:api-options="apiOptions"
+						:model-type="modelType"
+						:model-id="modelId"
+						:errors="validationErrors"
+						@schema-type-change="handleSchemaTypeChange"
+						@schema-markup-change="handleSchemaMarkupChange"
+					/>
+				</template>
+
+				<template #hreflang>
+					<HreflangTab
+						:data="displayData"
+						:errors="validationErrors"
+						@change="handleHreflangChange"
+					/>
+				</template>
+
+				<template #sitemap>
+					<SitemapTab
+						:data="displayData"
+						:errors="validationErrors"
+						@change="handleFieldChange"
+					/>
+				</template>
+			</Tabs>
+
+			<div class="mt-4 flex items-center gap-2">
+				<Button
+					color="primary"
+					@click="handleSave"
+					:disabled="saving || !dirty"
+				>
+					{{ saving ? 'Saving...' : 'Save SEO Settings' }}
+				</Button>
+
+				<span v-if="dirty" class="text-sm text-warning">Unsaved changes</span>
+			</div>
+		</template>
+	</div>
+</template>

--- a/resources/js/vue/components/admin/SitemapTab.vue
+++ b/resources/js/vue/components/admin/SitemapTab.vue
@@ -11,6 +11,8 @@
 -->
 
 <script setup lang="ts">
+import { ref, watch } from 'vue';
+
 import { Checkbox, Input, Select } from '@artisanpack-ui/vue';
 
 import type { SeoMetaResponse } from '../../../types/seo-data';
@@ -26,7 +28,7 @@ const CHANGEFREQ_OPTIONS = [
 	{ value: 'never', name: 'Never' },
 ];
 
-defineProps<{
+const props = defineProps<{
 	data: SeoMetaResponse;
 	errors?: Record<string, string[]>;
 }>();
@@ -35,8 +37,15 @@ const emit = defineEmits<{
 	'change': [field: string, value: unknown];
 }>();
 
-function handlePriorityChange( rawValue: string ): void {
-	const trimmed = String( rawValue ).trim();
+const priorityStr = ref( String( props.data.sitemap_priority ?? '' ) );
+
+// Sync from parent when data changes externally
+watch( () => props.data.sitemap_priority, ( newVal ) => {
+	priorityStr.value = String( newVal ?? '' );
+} );
+
+function commitPriority(): void {
+	const trimmed = priorityStr.value.trim();
 
 	if ( !trimmed ) {
 		emit( 'change', 'sitemap_priority', null );
@@ -72,8 +81,8 @@ function handlePriorityChange( rawValue: string ): void {
 
 			<Input
 				label="Priority"
-				:model-value="data.sitemap_priority ?? ''"
-				@update:model-value="handlePriorityChange( String( $event ) )"
+				v-model="priorityStr"
+				@blur="commitPriority"
 				type="number"
 				:min="0"
 				:max="1"

--- a/resources/js/vue/components/admin/SitemapTab.vue
+++ b/resources/js/vue/components/admin/SitemapTab.vue
@@ -1,0 +1,86 @@
+<!--
+  SitemapTab component.
+
+  Tab for configuring sitemap inclusion settings including
+  toggle, change frequency, and priority.
+
+  @package    ArtisanPack_UI
+  @subpackage SEO
+
+  @since      1.1.0
+-->
+
+<script setup lang="ts">
+import { Checkbox, Input, Select } from '@artisanpack-ui/vue';
+
+import type { SeoMetaResponse } from '../../../types/seo-data';
+
+const CHANGEFREQ_OPTIONS = [
+	{ value: '', name: 'Default' },
+	{ value: 'always', name: 'Always' },
+	{ value: 'hourly', name: 'Hourly' },
+	{ value: 'daily', name: 'Daily' },
+	{ value: 'weekly', name: 'Weekly' },
+	{ value: 'monthly', name: 'Monthly' },
+	{ value: 'yearly', name: 'Yearly' },
+	{ value: 'never', name: 'Never' },
+];
+
+defineProps<{
+	data: SeoMetaResponse;
+	errors?: Record<string, string[]>;
+}>();
+
+const emit = defineEmits<{
+	'change': [field: string, value: unknown];
+}>();
+
+function handlePriorityChange( rawValue: string ): void {
+	const trimmed = String( rawValue ).trim();
+
+	if ( !trimmed ) {
+		emit( 'change', 'sitemap_priority', null );
+
+		return;
+	}
+
+	const parsed = parseFloat( trimmed );
+	emit( 'change', 'sitemap_priority', Number.isFinite( parsed ) ? parsed : null );
+}
+</script>
+
+<template>
+	<div class="flex flex-col gap-4">
+		<Checkbox
+			label="Exclude from Sitemap"
+			:model-value="data.exclude_from_sitemap"
+			@update:model-value="emit( 'change', 'exclude_from_sitemap', $event )"
+			hint="When checked, this page will not appear in the XML sitemap"
+		/>
+
+		<template v-if="!data.exclude_from_sitemap">
+			<Select
+				label="Change Frequency"
+				:model-value="data.sitemap_changefreq ?? ''"
+				@update:model-value="emit( 'change', 'sitemap_changefreq', $event || null )"
+				:options="CHANGEFREQ_OPTIONS"
+				option-value="value"
+				option-label="name"
+				hint="How often this page is likely to change"
+				:error="errors?.sitemap_changefreq?.[0]"
+			/>
+
+			<Input
+				label="Priority"
+				:model-value="data.sitemap_priority ?? ''"
+				@update:model-value="handlePriorityChange( String( $event ) )"
+				type="number"
+				:min="0"
+				:max="1"
+				:step="0.1"
+				hint="Value between 0.0 and 1.0 (default: 0.5)"
+				:error="errors?.sitemap_priority?.[0]"
+			/>
+		</template>
+	</div>
+</template>

--- a/resources/js/vue/components/admin/SocialPreview.vue
+++ b/resources/js/vue/components/admin/SocialPreview.vue
@@ -1,0 +1,118 @@
+<!--
+  SocialPreview component.
+
+  Displays live Open Graph and Twitter Card previews showing
+  how shared links will appear on social media platforms.
+
+  @package    ArtisanPack_UI
+  @subpackage SEO
+
+  @since      1.1.0
+-->
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+
+import { Card, Tabs } from '@artisanpack-ui/vue';
+
+import type { SeoMetaResponse } from '../../../types/seo-data';
+
+const props = withDefaults( defineProps<{
+	data: SeoMetaResponse;
+	defaultUrl?: string;
+	className?: string;
+}>(), {
+	defaultUrl: '',
+	className: undefined,
+} );
+
+const activeTab = ref( 'facebook' );
+
+const ogTitle       = computed( () => props.data.og_title || props.data.meta_title || 'Page Title' );
+const ogDescription = computed( () => props.data.og_description || props.data.meta_description || '' );
+const ogImage       = computed( () => props.data.og_image );
+const ogSiteName    = computed( () => props.data.og_site_name || '' );
+
+const twTitle       = computed( () => props.data.twitter_title || props.data.meta_title || 'Page Title' );
+const twDescription = computed( () => props.data.twitter_description || props.data.meta_description || '' );
+const twImage       = computed( () => props.data.twitter_image || props.data.og_image );
+const twCardType    = computed( () => props.data.twitter_card || 'summary' );
+const isLargeImage  = computed( () => 'summary_large_image' === twCardType.value );
+
+const displayDomain = computed( () => {
+	const url = props.data.canonical_url || props.defaultUrl;
+
+	try {
+		return new URL( url ).hostname;
+	} catch {
+		return url || 'example.com';
+	}
+} );
+
+const tabs = [
+	{ name: 'facebook', label: 'Facebook / Open Graph' },
+	{ name: 'twitter', label: 'Twitter / X' },
+];
+</script>
+
+<template>
+	<Card :class="className">
+		<div class="p-4">
+			<p class="text-xs text-base-content/50 mb-2">Social Media Preview</p>
+
+			<Tabs :tabs="tabs" v-model:active-tab="activeTab" size="sm">
+				<template #facebook>
+					<div class="border border-base-300 rounded-lg overflow-hidden max-w-lg mt-3">
+						<div v-if="ogImage" class="aspect-[1.91/1] bg-base-200 overflow-hidden">
+							<img :src="ogImage" alt="Open Graph preview" class="w-full h-full object-cover" />
+						</div>
+						<div v-else class="aspect-[1.91/1] bg-base-200 flex items-center justify-center">
+							<span class="text-base-content/30 text-sm">No image set</span>
+						</div>
+
+						<div class="p-3 bg-base-100">
+							<p class="text-xs text-base-content/50 uppercase tracking-wide mb-1">{{ displayDomain }}</p>
+							<h4 class="font-semibold text-base-content leading-tight mb-1 line-clamp-2">{{ ogTitle }}</h4>
+							<p v-if="ogDescription" class="text-sm text-base-content/60 line-clamp-2">{{ ogDescription }}</p>
+							<p v-if="ogSiteName" class="text-xs text-base-content/40 mt-1">{{ ogSiteName }}</p>
+						</div>
+					</div>
+				</template>
+
+				<template #twitter>
+					<!-- Large image card -->
+					<div v-if="isLargeImage" class="border border-base-300 rounded-2xl overflow-hidden max-w-lg mt-3">
+						<div v-if="twImage" class="aspect-[2/1] bg-base-200 overflow-hidden">
+							<img :src="twImage" alt="Twitter Card preview" class="w-full h-full object-cover" />
+						</div>
+						<div v-else class="aspect-[2/1] bg-base-200 flex items-center justify-center">
+							<span class="text-base-content/30 text-sm">No image set</span>
+						</div>
+
+						<div class="p-3 bg-base-100">
+							<h4 class="font-semibold text-base-content leading-tight mb-0.5 line-clamp-1">{{ twTitle }}</h4>
+							<p v-if="twDescription" class="text-sm text-base-content/60 line-clamp-2 mb-1">{{ twDescription }}</p>
+							<p class="text-xs text-base-content/40">{{ displayDomain }}</p>
+						</div>
+					</div>
+
+					<!-- Summary card (side-by-side) -->
+					<div v-else class="border border-base-300 rounded-2xl overflow-hidden max-w-lg flex mt-3">
+						<div class="w-32 h-32 shrink-0 bg-base-200 overflow-hidden">
+							<img v-if="twImage" :src="twImage" alt="Twitter Card preview" class="w-full h-full object-cover" />
+							<div v-else class="w-full h-full flex items-center justify-center">
+								<span class="text-base-content/30 text-xs">No image</span>
+							</div>
+						</div>
+
+						<div class="p-3 bg-base-100 flex flex-col justify-center min-w-0">
+							<p class="text-xs text-base-content/40 mb-0.5">{{ displayDomain }}</p>
+							<h4 class="font-semibold text-base-content leading-tight mb-0.5 line-clamp-2 text-sm">{{ twTitle }}</h4>
+							<p v-if="twDescription" class="text-xs text-base-content/60 line-clamp-2">{{ twDescription }}</p>
+						</div>
+					</div>
+				</template>
+			</Tabs>
+		</div>
+	</Card>
+</template>

--- a/resources/js/vue/components/admin/TwitterCardTab.vue
+++ b/resources/js/vue/components/admin/TwitterCardTab.vue
@@ -1,0 +1,89 @@
+<!--
+  TwitterCardTab component.
+
+  Tab for editing Twitter Card meta fields including card type,
+  title, description, image, site handle, and creator handle.
+
+  @package    ArtisanPack_UI
+  @subpackage SEO
+
+  @since      1.1.0
+-->
+
+<script setup lang="ts">
+import { Input, Select, Textarea } from '@artisanpack-ui/vue';
+
+import type { SeoMetaResponse } from '../../../types/seo-data';
+
+const CARD_TYPE_OPTIONS = [
+	{ value: 'summary', name: 'Summary' },
+	{ value: 'summary_large_image', name: 'Summary with Large Image' },
+	{ value: 'app', name: 'App' },
+	{ value: 'player', name: 'Player' },
+];
+
+defineProps<{
+	data: SeoMetaResponse;
+	errors?: Record<string, string[]>;
+}>();
+
+const emit = defineEmits<{
+	'change': [field: string, value: unknown];
+}>();
+</script>
+
+<template>
+	<div class="flex flex-col gap-4">
+		<Select
+			label="Card Type"
+			:model-value="data.twitter_card ?? 'summary'"
+			@update:model-value="emit( 'change', 'twitter_card', $event )"
+			:options="CARD_TYPE_OPTIONS"
+			option-value="value"
+			option-label="name"
+			:error="errors?.twitter_card?.[0]"
+		/>
+
+		<Input
+			label="Twitter Title"
+			:model-value="data.twitter_title ?? ''"
+			@update:model-value="emit( 'change', 'twitter_title', $event )"
+			hint="Leave blank to use the meta title"
+			:error="errors?.twitter_title?.[0]"
+		/>
+
+		<Textarea
+			label="Twitter Description"
+			:model-value="data.twitter_description ?? ''"
+			@update:model-value="emit( 'change', 'twitter_description', $event )"
+			hint="Leave blank to use the meta description"
+			:error="errors?.twitter_description?.[0]"
+			:rows="3"
+		/>
+
+		<Input
+			label="Twitter Image URL"
+			:model-value="data.twitter_image ?? ''"
+			@update:model-value="emit( 'change', 'twitter_image', $event )"
+			hint="Minimum size: 120x120 for Summary, 300x157 for Large Image"
+			:error="errors?.twitter_image?.[0]"
+			type="url"
+		/>
+
+		<Input
+			label="Site Handle"
+			:model-value="data.twitter_site ?? ''"
+			@update:model-value="emit( 'change', 'twitter_site', $event )"
+			hint="The @username of the website (e.g. @example)"
+			:error="errors?.twitter_site?.[0]"
+		/>
+
+		<Input
+			label="Creator Handle"
+			:model-value="data.twitter_creator ?? ''"
+			@update:model-value="emit( 'change', 'twitter_creator', $event )"
+			hint="The @username of the content creator"
+			:error="errors?.twitter_creator?.[0]"
+		/>
+	</div>
+</template>

--- a/resources/js/vue/components/admin/index.ts
+++ b/resources/js/vue/components/admin/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Vue admin components barrel export.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.1.0
+ */
+
+export { default as BasicMetaTab } from './BasicMetaTab.vue';
+export { default as OpenGraphTab } from './OpenGraphTab.vue';
+export { default as TwitterCardTab } from './TwitterCardTab.vue';
+export { default as SchemaTab } from './SchemaTab.vue';
+export { default as HreflangTab } from './HreflangTab.vue';
+export { default as SitemapTab } from './SitemapTab.vue';
+export { default as SeoMetaEditor } from './SeoMetaEditor.vue';
+export { default as MetaPreview } from './MetaPreview.vue';
+export { default as SocialPreview } from './SocialPreview.vue';
+export { default as SeoAnalysisPanel } from './SeoAnalysisPanel.vue';
+export { default as RedirectManager } from './RedirectManager.vue';
+export { default as SeoDashboard } from './SeoDashboard.vue';

--- a/resources/js/vue/composables/index.ts
+++ b/resources/js/vue/composables/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Vue composables barrel export.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.1.0
+ */
+
+export { useApi, ApiError, ApiValidationError } from './useApi';
+export type { UseApiOptions, UseApiReturn } from './useApi';
+
+export { useSeoMeta } from './useSeoMeta';
+export type { UseSeoMetaOptions, UseSeoMetaReturn } from './useSeoMeta';
+
+export { useSeoAnalysis } from './useSeoAnalysis';
+export type { UseSeoAnalysisOptions, UseSeoAnalysisReturn } from './useSeoAnalysis';
+
+export { useRedirects } from './useRedirects';
+export type { UseRedirectsReturn, PaginatedRedirects } from './useRedirects';

--- a/resources/js/vue/composables/useApi.ts
+++ b/resources/js/vue/composables/useApi.ts
@@ -64,6 +64,10 @@ export interface UseApiReturn {
  * Reads a CSRF token from a meta tag if present.
  */
 function getMetaCsrfToken(): string | null {
+	if ( 'undefined' === typeof document ) {
+		return null;
+	}
+
 	const meta = document.querySelector( 'meta[name="csrf-token"]' );
 
 	return meta?.getAttribute( 'content' ) ?? null;
@@ -73,6 +77,10 @@ function getMetaCsrfToken(): string | null {
  * Reads the XSRF-TOKEN cookie set by Laravel Sanctum.
  */
 function getXsrfToken(): string | null {
+	if ( 'undefined' === typeof document ) {
+		return null;
+	}
+
 	const match = document.cookie.match( /(?:^|;\s*)XSRF-TOKEN=([^;]*)/ );
 
 	return match ? decodeURIComponent( match[1] ) : null;
@@ -129,7 +137,8 @@ export function useApi( options: UseApiOptions ): UseApiReturn {
 	}
 
 	function buildUrl( path: string, params?: Record<string, string> ): string {
-		const url = new URL( `${ baseUrl }${ path }`, window.location.origin );
+		const origin = 'undefined' !== typeof window ? window.location.origin : 'http://localhost';
+		const url    = new URL( `${ baseUrl }${ path }`, origin );
 
 		if ( params ) {
 			for ( const [key, value] of Object.entries( params ) ) {
@@ -150,7 +159,7 @@ export function useApi( options: UseApiOptions ): UseApiReturn {
 		if ( 422 === response.status ) {
 			try {
 				const data = await response.json();
-				throw new ApiValidationError( data.message, data.errors, 422 );
+				throw new ApiValidationError( data.message ?? 'Validation failed.', data.errors ?? {}, 422 );
 			} catch ( err ) {
 				if ( err instanceof ApiValidationError ) {
 					throw err;

--- a/resources/js/vue/composables/useApi.ts
+++ b/resources/js/vue/composables/useApi.ts
@@ -1,0 +1,236 @@
+/**
+ * useApi composable for authenticated API communication.
+ *
+ * Provides typed methods for GET, POST, PUT, and DELETE requests
+ * to the SEO REST API with error handling and CSRF token support.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.1.0
+ */
+
+import { onUnmounted } from 'vue';
+
+/** Error class for API responses with validation errors. */
+export class ApiValidationError extends Error {
+	public readonly errors: Record<string, string[]>;
+	public readonly status: number;
+
+	constructor( message: string, errors: Record<string, string[]>, status: number ) {
+		super( message );
+		this.name = 'ApiValidationError';
+		this.errors = errors;
+		this.status = status;
+	}
+}
+
+/** Error class for general API errors. */
+export class ApiError extends Error {
+	public readonly status: number;
+
+	constructor( message: string, status: number ) {
+		super( message );
+		this.name = 'ApiError';
+		this.status = status;
+	}
+}
+
+/** Options for configuring the useApi composable. */
+export interface UseApiOptions {
+	/** Base URL for the SEO API (e.g. "/api/seo"). */
+	baseUrl: string;
+	/** Optional CSRF token for non-API middleware. */
+	csrfToken?: string;
+	/** Optional authorization header value (e.g. "Bearer token"). */
+	authorization?: string;
+	/** Fetch credentials mode. Defaults to 'include' for cross-origin Sanctum support. */
+	credentials?: RequestCredentials;
+}
+
+/** Return type of the useApi composable. */
+export interface UseApiReturn {
+	/** Perform a GET request. */
+	get: <T>( path: string, params?: Record<string, string> ) => Promise<T>;
+	/** Perform a POST request with JSON body. */
+	post: <T>( path: string, body?: unknown ) => Promise<T>;
+	/** Perform a PUT request with JSON body. */
+	put: <T>( path: string, body?: unknown ) => Promise<T>;
+	/** Perform a DELETE request. */
+	del: <T = void>( path: string ) => Promise<T>;
+}
+
+/**
+ * Reads a CSRF token from a meta tag if present.
+ */
+function getMetaCsrfToken(): string | null {
+	const meta = document.querySelector( 'meta[name="csrf-token"]' );
+
+	return meta?.getAttribute( 'content' ) ?? null;
+}
+
+/**
+ * Reads the XSRF-TOKEN cookie set by Laravel Sanctum.
+ */
+function getXsrfToken(): string | null {
+	const match = document.cookie.match( /(?:^|;\s*)XSRF-TOKEN=([^;]*)/ );
+
+	return match ? decodeURIComponent( match[1] ) : null;
+}
+
+/**
+ * Vue composable for making authenticated API calls.
+ *
+ * @example
+ * ```ts
+ * const { get, post, put, del } = useApi({ baseUrl: '/api/seo' });
+ * const meta = await get<{ data: SeoMetaResponse }>('/meta/post/1');
+ * ```
+ */
+export function useApi( options: UseApiOptions ): UseApiReturn {
+	const { baseUrl, csrfToken, authorization, credentials = 'include' } = options;
+	const abortControllers = new Map<string, AbortController>();
+
+	onUnmounted( () => {
+		for ( const controller of abortControllers.values() ) {
+			controller.abort();
+		}
+
+		abortControllers.clear();
+	} );
+
+	function buildHeaders(): Record<string, string> {
+		const headers: Record<string, string> = {
+			'Accept': 'application/json',
+			'Content-Type': 'application/json',
+		};
+
+		if ( csrfToken ) {
+			headers['X-CSRF-TOKEN'] = csrfToken;
+		} else {
+			const xsrfToken = getXsrfToken();
+
+			if ( xsrfToken ) {
+				headers['X-XSRF-TOKEN'] = xsrfToken;
+			} else {
+				const metaToken = getMetaCsrfToken();
+
+				if ( metaToken ) {
+					headers['X-CSRF-TOKEN'] = metaToken;
+				}
+			}
+		}
+
+		if ( authorization ) {
+			headers['Authorization'] = authorization;
+		}
+
+		return headers;
+	}
+
+	function buildUrl( path: string, params?: Record<string, string> ): string {
+		const url = new URL( `${ baseUrl }${ path }`, window.location.origin );
+
+		if ( params ) {
+			for ( const [key, value] of Object.entries( params ) ) {
+				if ( value !== undefined && value !== '' ) {
+					url.searchParams.set( key, value );
+				}
+			}
+		}
+
+		return url.toString();
+	}
+
+	async function handleResponse<T>( response: Response ): Promise<T> {
+		if ( 204 === response.status ) {
+			return undefined as T;
+		}
+
+		if ( 422 === response.status ) {
+			try {
+				const data = await response.json();
+				throw new ApiValidationError( data.message, data.errors, 422 );
+			} catch ( err ) {
+				if ( err instanceof ApiValidationError ) {
+					throw err;
+				}
+
+				throw new ApiValidationError( 'Validation failed.', {}, 422 );
+			}
+		}
+
+		if ( !response.ok ) {
+			let message = `Request failed with status ${ response.status }`;
+
+			try {
+				const data = await response.json();
+				message = data.message;
+			} catch {
+				// Use the default message
+			}
+
+			throw new ApiError( message, response.status );
+		}
+
+		return response.json() as Promise<T>;
+	}
+
+	async function get<T>( path: string, params?: Record<string, string> ): Promise<T> {
+		const url = buildUrl( path, params );
+		const key = `GET:${ url }`;
+		abortControllers.get( key )?.abort();
+
+		const controller = new AbortController();
+		abortControllers.set( key, controller );
+
+		try {
+			const response = await fetch( url, {
+				method: 'GET',
+				headers: buildHeaders(),
+				credentials,
+				signal: controller.signal,
+			} );
+
+			return handleResponse<T>( response );
+		} finally {
+			if ( abortControllers.get( key ) === controller ) {
+				abortControllers.delete( key );
+			}
+		}
+	}
+
+	async function post<T>( path: string, body?: unknown ): Promise<T> {
+		const response = await fetch( buildUrl( path ), {
+			method: 'POST',
+			headers: buildHeaders(),
+			credentials,
+			body: body !== undefined ? JSON.stringify( body ) : undefined,
+		} );
+
+		return handleResponse<T>( response );
+	}
+
+	async function put<T>( path: string, body?: unknown ): Promise<T> {
+		const response = await fetch( buildUrl( path ), {
+			method: 'PUT',
+			headers: buildHeaders(),
+			credentials,
+			body: body !== undefined ? JSON.stringify( body ) : undefined,
+		} );
+
+		return handleResponse<T>( response );
+	}
+
+	async function del<T = void>( path: string ): Promise<T> {
+		const response = await fetch( buildUrl( path ), {
+			method: 'DELETE',
+			headers: buildHeaders(),
+			credentials,
+		} );
+
+		return handleResponse<T>( response );
+	}
+
+	return { get, post, put, del };
+}

--- a/resources/js/vue/composables/useRedirects.ts
+++ b/resources/js/vue/composables/useRedirects.ts
@@ -1,0 +1,302 @@
+/**
+ * useRedirects composable for managing URL redirects.
+ *
+ * Provides CRUD operations, filtering, sorting, pagination,
+ * bulk actions, and URL testing for redirects.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.1.0
+ *
+ * @example
+ * ```ts
+ * const { redirects, loading, createRedirect, setFilters } = useRedirects({
+ *     baseUrl: '/api/seo',
+ * });
+ * ```
+ */
+
+import { onUnmounted, ref, watch } from 'vue';
+
+import type { Ref } from 'vue';
+
+import type { UseApiOptions } from './useApi';
+import { useApi } from './useApi';
+
+import type { Redirect, RedirectTestResult } from '../../types/redirect';
+import type { RedirectFilterOptions, RedirectSortOptions } from '../../types/components';
+
+/** Paginated response shape from the redirects API. */
+export interface PaginatedRedirects {
+	data: Redirect[];
+	meta: {
+		current_page: number;
+		last_page: number;
+		per_page: number;
+		total: number;
+	};
+}
+
+/** Return type of the useRedirects composable. */
+export interface UseRedirectsReturn {
+	redirects: Ref<Redirect[]>;
+	meta: Ref<PaginatedRedirects['meta'] | null>;
+	loading: Ref<boolean>;
+	mutating: Ref<boolean>;
+	error: Ref<string | null>;
+	validationErrors: Ref<Record<string, string[]>>;
+	filters: Ref<RedirectFilterOptions>;
+	sort: Ref<RedirectSortOptions>;
+	page: Ref<number>;
+	fetchRedirects: () => Promise<void>;
+	createRedirect: ( data: Record<string, unknown> ) => Promise<Redirect | null>;
+	updateRedirect: ( id: number, data: Record<string, unknown> ) => Promise<Redirect | null>;
+	deleteRedirect: ( id: number ) => Promise<boolean>;
+	bulkAction: ( action: string, ids: number[], statusCode?: number ) => Promise<boolean>;
+	testUrl: ( url: string ) => Promise<RedirectTestResult | null>;
+	setFilters: ( newFilters: RedirectFilterOptions ) => void;
+	setSort: ( newSort: RedirectSortOptions ) => void;
+	setPage: ( newPage: number ) => void;
+}
+
+export function useRedirects( options: UseApiOptions ): UseRedirectsReturn {
+	const api = useApi( options );
+
+	const redirects        = ref<Redirect[]>( [] );
+	const meta             = ref<PaginatedRedirects['meta'] | null>( null );
+	const loading          = ref( true );
+	const mutating         = ref( false );
+	const error            = ref<string | null>( null );
+	const validationErrors = ref<Record<string, string[]>>( {} );
+	const filters          = ref<RedirectFilterOptions>( {} );
+	const sort             = ref<RedirectSortOptions>( { field: 'created_at', direction: 'desc' } );
+	const page             = ref( 1 );
+
+	let mounted        = true;
+	let fetchRequestId = 0;
+
+	onUnmounted( () => {
+		mounted = false;
+	} );
+
+	async function fetchRedirects(): Promise<void> {
+		fetchRequestId += 1;
+		const currentRequestId = fetchRequestId;
+
+		loading.value = true;
+		error.value   = null;
+
+		const params: Record<string, string> = {
+			page: String( page.value ),
+			sort_by: sort.value.field,
+			sort_order: sort.value.direction,
+		};
+
+		if ( filters.value.search ) {
+			params.search = filters.value.search;
+		}
+
+		if ( filters.value.status_code ) {
+			params.status_code = String( filters.value.status_code );
+		}
+
+		if ( filters.value.match_type ) {
+			params.match_type = filters.value.match_type;
+		}
+
+		if ( undefined !== filters.value.is_active ) {
+			params.is_active = filters.value.is_active ? '1' : '0';
+		}
+
+		try {
+			const response = await api.get<PaginatedRedirects>( '/redirects', params );
+
+			if ( mounted && currentRequestId === fetchRequestId ) {
+				redirects.value = response.data;
+				meta.value      = response.meta;
+			}
+		} catch ( err ) {
+			if ( mounted && currentRequestId === fetchRequestId ) {
+				error.value = err instanceof Error ? err.message : 'Failed to load redirects.';
+			}
+		} finally {
+			if ( mounted && currentRequestId === fetchRequestId ) {
+				loading.value = false;
+			}
+		}
+	}
+
+	async function createRedirect( data: Record<string, unknown> ): Promise<Redirect | null> {
+		mutating.value         = true;
+		error.value            = null;
+		validationErrors.value = {};
+
+		try {
+			const response = await api.post<{ data: Redirect }>( '/redirects', data );
+
+			if ( mounted ) {
+				await fetchRedirects();
+				mutating.value = false;
+			}
+
+			return response.data;
+		} catch ( err: unknown ) {
+			if ( mounted ) {
+				if ( err && typeof err === 'object' && 'errors' in err ) {
+					const validationErr = err as { errors: Record<string, string[]>; message: string };
+					validationErrors.value = validationErr.errors;
+					error.value            = validationErr.message;
+				} else {
+					error.value = err instanceof Error ? err.message : 'Failed to create redirect.';
+				}
+
+				mutating.value = false;
+			}
+
+			return null;
+		}
+	}
+
+	async function updateRedirect( id: number, data: Record<string, unknown> ): Promise<Redirect | null> {
+		mutating.value         = true;
+		error.value            = null;
+		validationErrors.value = {};
+
+		try {
+			const response = await api.put<{ data: Redirect }>( `/redirects/${ id }`, data );
+
+			if ( mounted ) {
+				await fetchRedirects();
+				mutating.value = false;
+			}
+
+			return response.data;
+		} catch ( err: unknown ) {
+			if ( mounted ) {
+				if ( err && typeof err === 'object' && 'errors' in err ) {
+					const validationErr = err as { errors: Record<string, string[]>; message: string };
+					validationErrors.value = validationErr.errors;
+					error.value            = validationErr.message;
+				} else {
+					error.value = err instanceof Error ? err.message : 'Failed to update redirect.';
+				}
+
+				mutating.value = false;
+			}
+
+			return null;
+		}
+	}
+
+	async function deleteRedirect( id: number ): Promise<boolean> {
+		mutating.value = true;
+		error.value    = null;
+
+		try {
+			await api.del( `/redirects/${ id }` );
+
+			if ( mounted ) {
+				await fetchRedirects();
+				mutating.value = false;
+			}
+
+			return true;
+		} catch ( err ) {
+			if ( mounted ) {
+				error.value    = err instanceof Error ? err.message : 'Failed to delete redirect.';
+				mutating.value = false;
+			}
+
+			return false;
+		}
+	}
+
+	async function bulkAction( action: string, ids: number[], statusCode?: number ): Promise<boolean> {
+		mutating.value = true;
+		error.value    = null;
+
+		try {
+			const body: Record<string, unknown> = { action, ids };
+
+			if ( statusCode ) {
+				body.status_code = statusCode;
+			}
+
+			await api.post( '/redirects/bulk', body );
+
+			if ( mounted ) {
+				await fetchRedirects();
+				mutating.value = false;
+			}
+
+			return true;
+		} catch ( err ) {
+			if ( mounted ) {
+				error.value    = err instanceof Error ? err.message : 'Bulk action failed.';
+				mutating.value = false;
+			}
+
+			return false;
+		}
+	}
+
+	async function testUrl( url: string ): Promise<RedirectTestResult | null> {
+		error.value = null;
+
+		try {
+			const response = await api.post<{ data: RedirectTestResult }>(
+				'/redirects/test',
+				{ url },
+			);
+
+			return response.data;
+		} catch ( err ) {
+			if ( mounted ) {
+				error.value = err instanceof Error ? err.message : 'URL test failed.';
+			}
+
+			return null;
+		}
+	}
+
+	function setFilters( newFilters: RedirectFilterOptions ): void {
+		filters.value = newFilters;
+		page.value    = 1;
+	}
+
+	function setSort( newSort: RedirectSortOptions ): void {
+		sort.value = newSort;
+		page.value = 1;
+	}
+
+	function setPage( newPage: number ): void {
+		page.value = newPage;
+	}
+
+	// Auto-fetch when reactive dependencies change
+	watch( [page, sort, filters], () => {
+		fetchRedirects();
+	}, { deep: true, immediate: true } );
+
+	return {
+		redirects: redirects as Ref<Redirect[]>,
+		meta: meta as Ref<PaginatedRedirects['meta'] | null>,
+		loading,
+		mutating,
+		error,
+		validationErrors,
+		filters,
+		sort,
+		page,
+		fetchRedirects,
+		createRedirect,
+		updateRedirect,
+		deleteRedirect,
+		bulkAction,
+		testUrl,
+		setFilters,
+		setSort,
+		setPage,
+	};
+}

--- a/resources/js/vue/composables/useSeoAnalysis.ts
+++ b/resources/js/vue/composables/useSeoAnalysis.ts
@@ -1,0 +1,220 @@
+/**
+ * useSeoAnalysis composable for running and displaying SEO content analysis.
+ *
+ * Manages analysis state with debounced API calls for real-time feedback.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.1.0
+ *
+ * @example
+ * ```ts
+ * const { result, analyzing, analyzeDebounced } = useSeoAnalysis({
+ *     baseUrl: '/api/seo',
+ *     modelType: 'App\\Models\\Post',
+ *     modelId: 1,
+ * });
+ * ```
+ */
+
+import { onUnmounted, ref } from 'vue';
+
+import type { Ref } from 'vue';
+
+import type { UseApiOptions } from './useApi';
+import { useApi } from './useApi';
+
+import type { AnalysisGrade, AnalysisGradeColor, AnalysisResultResponse } from '../../types/analysis';
+
+/** Grade label lookup. */
+const GRADE_LABELS: Record<AnalysisGrade, string> = {
+	good: 'Good',
+	ok: 'OK',
+	poor: 'Poor',
+};
+
+/** Grade color lookup. */
+const GRADE_COLORS: Record<AnalysisGrade, AnalysisGradeColor> = {
+	good: 'green',
+	ok: 'yellow',
+	poor: 'red',
+};
+
+function gradeFromScore( score: number ): AnalysisGrade {
+	if ( score >= 70 ) {
+		return 'good';
+	}
+
+	return score >= 40 ? 'ok' : 'poor';
+}
+
+/**
+ * Normalizes API responses into a consistent AnalysisResultResponse shape.
+ * Handles both cached (flat) and fresh (nested scores) formats.
+ */
+function normalizeResult( raw: Record<string, unknown> ): AnalysisResultResponse {
+	const overallScore = ( raw.overall_score as number ) ?? 0;
+	const grade        = ( raw.grade as AnalysisGrade ) ?? gradeFromScore( overallScore );
+
+	const scores = raw.scores as { readability: number; keyword: number; meta: number; content: number } | undefined;
+
+	const readability = scores?.readability ?? ( raw.readability_score as number ) ?? 0;
+	const keyword     = scores?.keyword ?? ( raw.keyword_score as number ) ?? 0;
+	const meta        = scores?.meta ?? ( raw.meta_score as number ) ?? 0;
+	const content     = scores?.content ?? ( raw.content_score as number ) ?? 0;
+
+	const rawPassed  = ( raw.passed_checks ?? [] ) as ( string | { message: string } )[];
+	const passedList = rawPassed.map( ( item ) =>
+		'string' === typeof item ? item : item.message,
+	);
+
+	const rawIssues = ( raw.issues ?? [] ) as ( string | { type: string; message: string } )[];
+	const issues    = rawIssues.map( ( item ) =>
+		'string' === typeof item ? { type: 'general', message: item } : item,
+	);
+
+	const rawSuggestions = ( raw.suggestions ?? [] ) as ( string | { type: string; message: string } )[];
+	const suggestions    = rawSuggestions.map( ( item ) =>
+		'string' === typeof item ? { type: 'general', message: item } : item,
+	);
+
+	return {
+		overall_score: overallScore,
+		grade,
+		grade_label: ( raw.grade_label as string ) ?? GRADE_LABELS[grade],
+		grade_color: ( raw.grade_color as AnalysisGradeColor ) ?? GRADE_COLORS[grade],
+		scores: { readability, keyword, meta, content },
+		focus_keyword: ( raw.focus_keyword as string ) ?? null,
+		word_count: ( raw.word_count as number ) ?? 0,
+		issues,
+		issue_count: ( raw.issue_count as number ) ?? issues.length,
+		suggestions,
+		suggestion_count: ( raw.suggestion_count as number ) ?? suggestions.length,
+		passed_checks: passedList,
+		passed_count: ( raw.passed_count as number ) ?? passedList.length,
+		analyzer_results: ( raw.analyzer_results ?? {} ) as AnalysisResultResponse['analyzer_results'],
+	};
+}
+
+/** Options for the useSeoAnalysis composable. */
+export interface UseSeoAnalysisOptions extends UseApiOptions {
+	/** The model type (e.g. "App\\Models\\Post"). */
+	modelType: string;
+	/** The model ID. */
+	modelId: number;
+	/** Debounce delay in milliseconds. Defaults to 1500. */
+	debounceMs?: number;
+}
+
+/** Return type of the useSeoAnalysis composable. */
+export interface UseSeoAnalysisReturn {
+	result: Ref<AnalysisResultResponse | null>;
+	analyzing: Ref<boolean>;
+	loading: Ref<boolean>;
+	error: Ref<string | null>;
+	analyze: ( focusKeyword?: string ) => Promise<void>;
+	analyzeDebounced: ( focusKeyword?: string ) => void;
+	fetchCached: () => Promise<void>;
+}
+
+export function useSeoAnalysis( options: UseSeoAnalysisOptions ): UseSeoAnalysisReturn {
+	const { modelType, modelId, debounceMs = 1500 } = options;
+	const api              = useApi( options );
+	const encodedModelType = encodeURIComponent( modelType );
+
+	const result    = ref<AnalysisResultResponse | null>( null );
+	const analyzing = ref( false );
+	const loading   = ref( true );
+	const error     = ref<string | null>( null );
+
+	let mounted       = true;
+	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+	let requestId     = 0;
+
+	onUnmounted( () => {
+		mounted = false;
+
+		if ( debounceTimer ) {
+			clearTimeout( debounceTimer );
+		}
+	} );
+
+	async function fetchCached(): Promise<void> {
+		loading.value = true;
+		error.value   = null;
+
+		try {
+			const response = await api.get<{ data: Record<string, unknown> | null }>(
+				`/analysis/${ encodedModelType }/${ modelId }`,
+			);
+
+			if ( mounted ) {
+				result.value = response.data ? normalizeResult( response.data ) : null;
+			}
+		} catch ( err: unknown ) {
+			const is404 = err && typeof err === 'object' && 'status' in err && 404 === ( err as { status: number } ).status;
+
+			if ( !is404 && mounted ) {
+				error.value = err instanceof Error ? err.message : 'Failed to load analysis.';
+			}
+		} finally {
+			if ( mounted ) {
+				loading.value = false;
+			}
+		}
+	}
+
+	async function analyze( focusKeyword?: string ): Promise<void> {
+		requestId += 1;
+		const currentRequestId = requestId;
+
+		analyzing.value = true;
+		error.value     = null;
+
+		try {
+			const response = await api.post<{ data: Record<string, unknown> | null }>(
+				'/analysis/analyze',
+				{
+					model_type: modelType,
+					model_id: modelId,
+					focus_keyword: focusKeyword ?? undefined,
+				},
+			);
+
+			if ( mounted && currentRequestId === requestId ) {
+				result.value = response.data ? normalizeResult( response.data ) : null;
+			}
+		} catch ( err ) {
+			if ( mounted && currentRequestId === requestId ) {
+				error.value = err instanceof Error ? err.message : 'Analysis failed.';
+			}
+		} finally {
+			if ( mounted && currentRequestId === requestId ) {
+				analyzing.value = false;
+			}
+		}
+	}
+
+	function analyzeDebounced( focusKeyword?: string ): void {
+		if ( debounceTimer ) {
+			clearTimeout( debounceTimer );
+		}
+
+		debounceTimer = setTimeout( () => {
+			analyze( focusKeyword );
+		}, debounceMs );
+	}
+
+	fetchCached();
+
+	return {
+		result: result as Ref<AnalysisResultResponse | null>,
+		analyzing,
+		loading,
+		error,
+		analyze,
+		analyzeDebounced,
+		fetchCached,
+	};
+}

--- a/resources/js/vue/composables/useSeoAnalysis.ts
+++ b/resources/js/vue/composables/useSeoAnalysis.ts
@@ -141,6 +141,9 @@ export function useSeoAnalysis( options: UseSeoAnalysisOptions ): UseSeoAnalysis
 	} );
 
 	async function fetchCached(): Promise<void> {
+		requestId += 1;
+		const currentRequestId = requestId;
+
 		loading.value = true;
 		error.value   = null;
 
@@ -149,17 +152,17 @@ export function useSeoAnalysis( options: UseSeoAnalysisOptions ): UseSeoAnalysis
 				`/analysis/${ encodedModelType }/${ modelId }`,
 			);
 
-			if ( mounted ) {
+			if ( mounted && currentRequestId === requestId ) {
 				result.value = response.data ? normalizeResult( response.data ) : null;
 			}
 		} catch ( err: unknown ) {
 			const is404 = err && typeof err === 'object' && 'status' in err && 404 === ( err as { status: number } ).status;
 
-			if ( !is404 && mounted ) {
+			if ( !is404 && mounted && currentRequestId === requestId ) {
 				error.value = err instanceof Error ? err.message : 'Failed to load analysis.';
 			}
 		} finally {
-			if ( mounted ) {
+			if ( mounted && currentRequestId === requestId ) {
 				loading.value = false;
 			}
 		}

--- a/resources/js/vue/composables/useSeoMeta.ts
+++ b/resources/js/vue/composables/useSeoMeta.ts
@@ -1,0 +1,157 @@
+/**
+ * useSeoMeta composable for fetching and updating SEO metadata.
+ *
+ * Manages SEO data lifecycle for a specific model, including
+ * loading, saving, and preview data.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.1.0
+ *
+ * @example
+ * ```ts
+ * const { data, loading, updateMeta } = useSeoMeta({
+ *     baseUrl: '/api/seo',
+ *     modelType: 'App\\Models\\Post',
+ *     modelId: 1,
+ * });
+ * ```
+ */
+
+import { onUnmounted, ref, watch } from 'vue';
+
+import type { Ref } from 'vue';
+
+import type { UseApiOptions } from './useApi';
+import { useApi } from './useApi';
+
+import type { SeoMetaResponse, SeoPreviewResponse } from '../../types/seo-data';
+
+/** Options for the useSeoMeta composable. */
+export interface UseSeoMetaOptions extends UseApiOptions {
+	/** The model type (e.g. "App\\Models\\Post"). */
+	modelType: string;
+	/** The model ID. */
+	modelId: number;
+	/** Optional initial data to avoid an initial fetch. */
+	initialData?: SeoMetaResponse;
+}
+
+/** Return type of the useSeoMeta composable. */
+export interface UseSeoMetaReturn {
+	data: Ref<SeoMetaResponse | null>;
+	preview: Ref<SeoPreviewResponse | null>;
+	loading: Ref<boolean>;
+	saving: Ref<boolean>;
+	error: Ref<string | null>;
+	validationErrors: Ref<Record<string, string[]>>;
+	fetchMeta: () => Promise<void>;
+	fetchPreview: () => Promise<void>;
+	updateMeta: ( updates: Record<string, unknown> ) => Promise<SeoMetaResponse | null>;
+}
+
+export function useSeoMeta( options: UseSeoMetaOptions ): UseSeoMetaReturn {
+	const { modelType, modelId, initialData } = options;
+	const api = useApi( options );
+	const encodedModelType = encodeURIComponent( modelType );
+
+	const data             = ref<SeoMetaResponse | null>( initialData ?? null );
+	const preview          = ref<SeoPreviewResponse | null>( null );
+	const loading          = ref( !initialData );
+	const saving           = ref( false );
+	const error            = ref<string | null>( null );
+	const validationErrors = ref<Record<string, string[]>>( {} );
+	let mounted            = true;
+
+	onUnmounted( () => {
+		mounted = false;
+	} );
+
+	async function fetchMeta(): Promise<void> {
+		loading.value = true;
+		error.value   = null;
+
+		try {
+			const response = await api.get<{ data: SeoMetaResponse | null }>(
+				`/meta/${ encodedModelType }/${ modelId }`,
+			);
+
+			if ( mounted ) {
+				data.value = response.data;
+			}
+		} catch ( err ) {
+			if ( mounted ) {
+				error.value = err instanceof Error ? err.message : 'Failed to load SEO data.';
+			}
+		} finally {
+			if ( mounted ) {
+				loading.value = false;
+			}
+		}
+	}
+
+	async function fetchPreview(): Promise<void> {
+		try {
+			const response = await api.get<{ data: SeoPreviewResponse }>(
+				`/meta/${ encodedModelType }/${ modelId }/preview`,
+			);
+
+			if ( mounted ) {
+				preview.value = response.data;
+			}
+		} catch {
+			// Preview failures are non-critical
+		}
+	}
+
+	async function updateMeta( updates: Record<string, unknown> ): Promise<SeoMetaResponse | null> {
+		saving.value           = true;
+		error.value            = null;
+		validationErrors.value = {};
+
+		try {
+			const response = await api.put<{ data: SeoMetaResponse }>(
+				`/meta/${ encodedModelType }/${ modelId }`,
+				updates,
+			);
+
+			if ( mounted ) {
+				data.value   = response.data;
+				saving.value = false;
+			}
+
+			return response.data;
+		} catch ( err: unknown ) {
+			if ( mounted ) {
+				if ( err && typeof err === 'object' && 'errors' in err ) {
+					const validationErr = err as { errors: Record<string, string[]>; message?: string };
+					validationErrors.value = validationErr.errors;
+					error.value            = validationErr.message ?? 'Validation failed.';
+				} else {
+					error.value = err instanceof Error ? err.message : 'Failed to save SEO data.';
+				}
+
+				saving.value = false;
+			}
+
+			return null;
+		}
+	}
+
+	if ( !initialData ) {
+		fetchMeta();
+	}
+
+	return {
+		data: data as Ref<SeoMetaResponse | null>,
+		preview: preview as Ref<SeoPreviewResponse | null>,
+		loading,
+		saving,
+		error,
+		validationErrors,
+		fetchMeta,
+		fetchPreview,
+		updateMeta,
+	};
+}

--- a/resources/js/vue/index.ts
+++ b/resources/js/vue/index.ts
@@ -1,0 +1,50 @@
+/**
+ * ArtisanPack UI SEO - Vue Components.
+ *
+ * Central export for all Vue SEO admin components and composables.
+ * Publish these components to your application with:
+ *
+ *   php artisan vendor:publish --tag=seo-vue
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.1.0
+ */
+
+// Composables
+export {
+	useApi,
+	ApiError,
+	ApiValidationError,
+	useSeoMeta,
+	useSeoAnalysis,
+	useRedirects,
+} from './composables';
+
+export type {
+	UseApiOptions,
+	UseApiReturn,
+	UseSeoMetaOptions,
+	UseSeoMetaReturn,
+	UseSeoAnalysisOptions,
+	UseSeoAnalysisReturn,
+	UseRedirectsReturn,
+	PaginatedRedirects,
+} from './composables';
+
+// Admin Components
+export {
+	BasicMetaTab,
+	OpenGraphTab,
+	TwitterCardTab,
+	SchemaTab,
+	HreflangTab,
+	SitemapTab,
+	SeoMetaEditor,
+	MetaPreview,
+	SocialPreview,
+	SeoAnalysisPanel,
+	RedirectManager,
+	SeoDashboard,
+} from './components/admin';

--- a/src/Providers/SEOServiceProvider.php
+++ b/src/Providers/SEOServiceProvider.php
@@ -225,6 +225,14 @@ class SEOServiceProvider extends ServiceProvider
 				'seo-react',
 			);
 
+			// Publish Vue components
+			$this->publishes(
+				[
+					__DIR__ . '/../../resources/js/vue' => resource_path( 'js/vendor/seo/vue' ),
+				],
+				'seo-vue',
+			);
+
 			// Publish all
 			$this->publishes(
 				[
@@ -233,6 +241,7 @@ class SEOServiceProvider extends ServiceProvider
 					__DIR__ . '/../../database/migrations'  => database_path( 'migrations' ),
 					__DIR__ . '/../../resources/js/types'   => resource_path( 'js/types/seo' ),
 					__DIR__ . '/../../resources/js/react'   => resource_path( 'js/vendor/seo/react' ),
+					__DIR__ . '/../../resources/js/vue'     => resource_path( 'js/vendor/seo/vue' ),
 				],
 				'seo',
 			);


### PR DESCRIPTION
## Summary

- Add 12 Vue 3 admin components (SeoMetaEditor with 6 tabs, MetaPreview, SocialPreview, SeoAnalysisPanel, RedirectManager, SeoDashboard) as publishable assets
- Add 4 Vue composables (useApi, useSeoMeta, useSeoAnalysis, useRedirects) for SEO REST API integration
- Update SEOServiceProvider with `seo-vue` publish tag for `php artisan vendor:publish --tag=seo-vue`
- Full parity with the React SEO components (#32)

Closes #33

## Changes

- **12 components** built with `<script setup lang="ts">` using `@artisanpack-ui/vue` consuming existing SEO REST API endpoints
- **4 composables** providing authenticated API communication, SEO metadata CRUD, debounced content analysis, and redirect management
- **Response normalization** handling both cached (flat) and fresh (nested) analysis API response formats
- **URL encoding** for model type path segments containing backslashes
- **Barrel exports** via `resources/js/vue/index.ts`

## Test plan

- [x] All 1301 existing tests pass
- [x] SeoMetaEditor loads and saves meta data across all 6 tabs
- [x] MetaPreview renders Google SERP snippet from live data
- [x] SocialPreview renders Facebook/Twitter card previews
- [x] SeoAnalysisPanel displays cached results (fresh analysis blocked by #40)
- [x] RedirectManager lists, creates, edits, deletes redirects with filtering/sorting
- [x] SeoDashboard shows redirect stats and analysis score
- [x] CodeRabbit review feedback addressed (1 pass, 3 findings fixed)

**Note:** Fresh analysis returns all-zero scores — tracked in #40 (affects all frameworks equally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New admin SEO editor with tabbed controls for meta, Open Graph, Twitter, schema, hreflang, sitemap and unsaved-change/save workflow
  * Live previews: Google search snippet and social card previews
  * SEO Analysis panel with scores, category progress and per-check details
  * Redirect manager with search, sort, pagination, bulk actions and URL testing
  * Admin SEO dashboard with redirect stats and recent redirects
* **Chores**
  * Packaged Vue UI assets for publishing alongside existing resources
<!-- end of auto-generated comment: release notes by coderabbit.ai -->