### PR TITLE
feat(ai): SEO agent suite — meta title/description, content analysis, schema, hreflang (#50–#54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **AI Feature Suite**: Five AI agents built on top of `artisanpack-ui/ai` for SEO workflows. Each ships with Livewire, React, and Vue trigger components plus a JSON API endpoint under `/api/seo/ai/`.
+  - `MetaTitleSuggestionAgent` — 3-5 CTR-optimized title variants ≤60 chars (#50)
+  - `MetaDescriptionAgent` — one 150-160 char meta description with keyword coverage (#51)
+  - `ContentAnalysisAgent` — structured quality score across four dimensions with actionable recommendations (#52)
+  - `SchemaGenerationAgent` — JSON-LD schema type suggestion + starter object, backed by the existing 14 supported schema types (#53)
+  - `HreflangSuggestionAgent` — cross-references hreflang relationships and surfaces gaps/inconsistencies (#54)
+- **Feature Registry Integration**: `SEOServiceProvider::aiFeatures()` auto-registers all five features with labels, default models, and descriptions.
+- **AI Trigger Components**: `<livewire:seo::ai-*>` Livewire components + `MetaTitleSuggestor`/`ContentAnalyzer`/etc. React and Vue components with the `useAiAgent` hook/composable.
+
+### Changed
+
+- Added `artisanpack-ui/ai: ^1.0` as a required dependency.
+
 ## [1.1.1] - 2026-06-09
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,28 @@ Before contributing, make sure you have:
 7. Push to your fork
 8. Create a merge/pull request
 
+### Local dependency on `artisanpack-ui/ai`
+
+The AI features shipped in 1.2.0 require `artisanpack-ui/ai`. For local
+development you have two options:
+
+- **Sibling checkout (recommended for AI-package co-development)**: clone
+  `artisanpack-ui/ai` into a sibling directory (e.g.
+  `~/Code/ArtisanPack UI Packages/ai`) and temporarily add the following block
+  to your local `composer.json` (do NOT commit this change):
+
+  ```json
+  "repositories": [
+      { "type": "path", "url": "../ai", "options": { "symlink": true } }
+  ],
+  ```
+
+  Then run `composer update artisanpack-ui/ai`. Revert the composer.json edit
+  before committing anything else.
+
+- **Packagist (default)**: once `artisanpack-ui/ai` is published, `composer install`
+  resolves it automatically with no extra setup.
+
 ## Issue Templates
 
 When creating an issue, you'll be prompted to choose a template. We have several templates to help you provide the right information:

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ class Post extends Model
 - **SEO Analysis**: 8 built-in analyzers for content quality scoring
 - **Performance Caching**: Comprehensive caching for meta tags, sitemaps, and redirects
 - **Admin Components**: Livewire components for visual SEO management
+- **AI Features**: Five AI agents for title/description suggestions, content analysis, schema generation, and hreflang gap detection (requires `artisanpack-ui/ai`)
 
 ## Components
 
@@ -73,10 +74,58 @@ class Post extends Model
 | `<livewire:hreflang-editor>` | Multi-language URL editor |
 | `<livewire:meta-preview>` | Search result preview |
 | `<livewire:social-preview>` | Social share preview |
+| `<livewire:seo::ai-meta-title-suggestor>` | AI-generated title variants |
+| `<livewire:seo::ai-meta-description-suggestor>` | AI-generated meta description |
+| `<livewire:seo::ai-content-analyzer>` | AI content quality scoring with recommendations |
+| `<livewire:seo::ai-schema-suggestor>` | AI JSON-LD schema type suggestion + starter object |
+| `<livewire:seo::ai-hreflang-suggestor>` | AI hreflang gap detection |
 
 ### Schema Types
 
 Article, BlogPosting, Product, Organization, Person, LocalBusiness, Event, Recipe, FAQPage, HowTo, BreadcrumbList, WebSite, WebPage, VideoObject
+
+## AI Features
+
+Five agents are shipped for use with the `artisanpack-ui/ai` foundation package. When `artisanpack-ui/ai` is installed and configured with credentials, the SEO service provider auto-registers each feature via `aiFeatures()`.
+
+| Feature key | Default model | Description |
+|---|---|---|
+| `seo.suggest_meta_title` | `claude-haiku-4-5` | Generate 3-5 SEO title variants (≤60 chars). |
+| `seo.suggest_meta_description` | `claude-haiku-4-5` | Generate one 150-160 character meta description. |
+| `seo.analyze_content` | `claude-sonnet-4-6` | Score content across keyword usage, readability, structure, and semantic completeness. |
+| `seo.generate_schema` | `claude-haiku-4-5` | Pick a JSON-LD schema type from the supported list and produce a starter object. |
+| `seo.suggest_hreflang` | `claude-haiku-4-5` | Cross-reference hreflang tags and surface missing or inconsistent relationships. |
+
+### Trigger surfaces
+
+Every feature ships trigger UI on all three supported frontends:
+
+- **Livewire** — the components listed above. Drop them into your editor views.
+- **React** — `MetaTitleSuggestor`, `MetaDescriptionSuggestor`, `ContentAnalyzer`, `SchemaSuggestor`, `HreflangSuggestor` under `@artisanpack-ui/seo/react` (or the published path). Backed by the `useAiAgent` hook.
+- **Vue** — the same five components under `@artisanpack-ui/seo/vue`, backed by the `useAiAgent` composable.
+
+React and Vue triggers call the JSON API at `/api/seo/ai/{feature}` — see the routes registered under `Route::prefix('ai')` in `routes/api.php` (`suggest-meta-title`, `suggest-meta-description`, `analyze-content`, `generate-schema`, `suggest-hreflang`).
+
+### Feature toggles
+
+Each feature honors the shared registry toggle. A disabled feature returns a `FeatureDisabledException` from the agent and a `409` from the API. Toggle at runtime via the `FeatureRegistry` facade:
+
+```php
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+
+app( FeatureRegistry::class )->disable( 'seo.analyze_content' );
+```
+
+Or set the initial state in `config/artisanpack.php`:
+
+```php
+'ai' => [
+    'features' => [
+        'seo.suggest_meta_title' => [ 'enabled' => true, 'model' => 'claude-haiku-4-5' ],
+        // ...
+    ],
+],
+```
 
 ## Documentation
 

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
   "require": {
     "php": "^8.2",
     "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+    "artisanpack-ui/ai": "^1.0",
     "artisanpack-ui/core": "^1.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,95 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4eee1eb5289a09a12a24d9459e767129",
+    "content-hash": "7fa8ee1131f636d4d5045c906b18877e",
     "packages": [
+        {
+            "name": "artisanpack-ui/ai",
+            "version": "1.0.0",
+            "dist": {
+                "type": "path",
+                "url": "../ai",
+                "reference": "082f1cd337742d34b8035d116c6c5ad8e5453fca"
+            },
+            "require": {
+                "artisanpack-ui/core": "^1.0",
+                "illuminate/support": "^12.0|^13.0",
+                "laravel/ai": "^0.8",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "artisanpack-ui/code-style": "^1.1",
+                "artisanpack-ui/code-style-pint": "^1.1",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "friendsofphp/php-cs-fixer": "^3.75",
+                "laravel/pint": "^1.26",
+                "livewire/livewire": "^3.6",
+                "orchestra/testbench": "^10.2|^11.0",
+                "pestphp/pest": "^3.8|^4.0",
+                "pestphp/pest-plugin-laravel": "^3.2|^4.1"
+            },
+            "suggest": {
+                "artisanpack-ui/cms-framework": "Automatically registers AI credentials, features, budget and cache setting groups under the CMS admin surface.",
+                "artisanpack-ui/livewire-ui-components": "Renders the AI Settings and Usage admin surfaces using x-artisanpack-* components.",
+                "livewire/livewire": "Required to mount the AI Settings and Usage dashboard Livewire components under cms-framework's admin nav."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "ArtisanPackUI\\Ai\\AiServiceProvider"
+                    ],
+                    "aliases": {
+                        "Ai": "ArtisanPackUI\\Ai\\Facades\\Ai"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "ArtisanPackUI\\Ai\\": "src/"
+                },
+                "files": [
+                    "src/helpers.php"
+                ]
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "lint": [
+                    "./vendor/bin/php-cs-fixer fix --dry-run --diff",
+                    "./vendor/bin/phpcs"
+                ],
+                "fix": [
+                    "./vendor/bin/php-cs-fixer fix"
+                ],
+                "cs": [
+                    "./vendor/bin/phpcs"
+                ],
+                "cs:fix": [
+                    "./vendor/bin/phpcbf"
+                ],
+                "test": [
+                    "./vendor/bin/pest"
+                ]
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jacob Martella",
+                    "email": "me@jacobmartella.com"
+                }
+            ],
+            "description": "Shared AI foundation for the ArtisanPack UI ecosystem, built on top of laravel/ai.",
+            "transport-options": {
+                "symlink": true,
+                "relative": true
+            }
+        },
         {
             "name": "artisanpack-ui/core",
             "version": "1.2.0",
@@ -74,6 +161,157 @@
                 "source": "https://github.com/ArtisanPack-UI/core/tree/v1.2.0"
             },
             "time": "2026-05-24T02:53:50+00:00"
+        },
+        {
+            "name": "aws/aws-crt-php",
+            "version": "v1.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/awslabs/aws-crt-php.git",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/awslabs/aws-crt-php/zipball/d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35||^5.6.3||^9.5",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "suggest": {
+                "ext-awscrt": "Make sure you install awscrt native extension to use any of the functionality."
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "AWS SDK Common Runtime Team",
+                    "email": "aws-sdk-common-runtime@amazon.com"
+                }
+            ],
+            "description": "AWS Common Runtime for PHP",
+            "homepage": "https://github.com/awslabs/aws-crt-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "crt",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/awslabs/aws-crt-php/issues",
+                "source": "https://github.com/awslabs/aws-crt-php/tree/v1.2.7"
+            },
+            "time": "2024-10-18T22:15:13+00:00"
+        },
+        {
+            "name": "aws/aws-sdk-php",
+            "version": "3.387.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aws/aws-sdk-php.git",
+                "reference": "20818be961ace3ef01c1aed3c247e71b26020149"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/20818be961ace3ef01c1aed3c247e71b26020149",
+                "reference": "20818be961ace3ef01c1aed3c247e71b26020149",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-crt-php": "^1.2.3",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/promises": "^2.0",
+                "guzzlehttp/psr7": "^2.4.5",
+                "mtdowling/jmespath.php": "^2.9.1",
+                "php": ">=8.1",
+                "psr/http-message": "^1.0 || ^2.0",
+                "symfony/filesystem": "^v5.4.45 || ^v6.4.3 || ^v7.1.0 || ^v8.0.0"
+            },
+            "require-dev": {
+                "andrewsville/php-token-reflection": "^1.4",
+                "aws/aws-php-sns-message-validator": "~1.0",
+                "behat/behat": "~3.0",
+                "composer/composer": "^2.7.8",
+                "dms/phpunit-arraysubset-asserts": "^v0.5.0",
+                "doctrine/cache": "~1.4",
+                "ext-dom": "*",
+                "ext-openssl": "*",
+                "ext-sockets": "*",
+                "phpunit/phpunit": "^10.0",
+                "psr/cache": "^2.0 || ^3.0",
+                "psr/simple-cache": "^2.0 || ^3.0",
+                "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
+                "yoast/phpunit-polyfills": "^2.0"
+            },
+            "suggest": {
+                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
+                "doctrine/cache": "To use the DoctrineCacheAdapter",
+                "ext-curl": "To send requests using cURL",
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
+                "ext-pcntl": "To use client-side monitoring",
+                "ext-sockets": "To use client-side monitoring"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Aws\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/data/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Amazon Web Services",
+                    "homepage": "https://aws.amazon.com"
+                }
+            ],
+            "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
+            "homepage": "https://aws.amazon.com/sdk-for-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "cloud",
+                "dynamodb",
+                "ec2",
+                "glacier",
+                "s3",
+                "sdk"
+            ],
+            "support": {
+                "forum": "https://github.com/aws/aws-sdk-php/discussions",
+                "issues": "https://github.com/aws/aws-sdk-php/issues",
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.387.3"
+            },
+            "time": "2026-07-06T18:13:24+00:00"
         },
         {
             "name": "brick/math",
@@ -1205,6 +1443,80 @@
             "time": "2026-05-23T22:00:21+00:00"
         },
         {
+            "name": "laravel/ai",
+            "version": "v0.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/ai.git",
+                "reference": "b23bc857576d7c4b3bb52ffd8be936ae74005d23"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/ai/zipball/b23bc857576d7c4b3bb52ffd8be936ae74005d23",
+                "reference": "b23bc857576d7c4b3bb52ffd8be936ae74005d23",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-sdk-php": "^3.339",
+                "illuminate/console": "^12.0|^13.0",
+                "illuminate/container": "^12.0|^13.0",
+                "illuminate/contracts": "^12.0|^13.0",
+                "illuminate/database": "^12.0|^13.0",
+                "illuminate/filesystem": "^12.0|^13.0",
+                "illuminate/json-schema": "^12.62|^13.15",
+                "illuminate/support": "^12.0|^13.0",
+                "laravel/prompts": "^0.3.6",
+                "laravel/serializable-closure": "^2.0",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "laravel/mcp": "^0.8",
+                "laravel/pint": "^1.26",
+                "mockery/mockery": "^1.6.12",
+                "orchestra/testbench": "^10.6|^11.0",
+                "pestphp/pest": "^3.0|^4.0",
+                "pestphp/pest-plugin-laravel": "^3.0|^4.0",
+                "phpstan/phpstan": "^2.1"
+            },
+            "suggest": {
+                "laravel/mcp": "Required to use MCP client tools or MCP server tools with Laravel AI agents."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Ai\\AiServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "functions.php"
+                ],
+                "psr-4": {
+                    "Laravel\\Ai\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The official AI SDK for Laravel.",
+            "homepage": "https://github.com/laravel/ai",
+            "keywords": [
+                "ai",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/ai/issues",
+                "source": "https://github.com/laravel/ai"
+            },
+            "time": "2026-06-10T11:23:35+00:00"
+        },
+        {
             "name": "laravel/framework",
             "version": "v12.62.0",
             "source": {
@@ -2207,6 +2519,72 @@
                 }
             ],
             "time": "2026-01-02T08:56:05+00:00"
+        },
+        {
+            "name": "mtdowling/jmespath.php",
+            "version": "2.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jmespath/jmespath.php.git",
+                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
+                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.17"
+            },
+            "require-dev": {
+                "composer/xdebug-handler": "^3.0.3",
+                "phpunit/phpunit": "^8.5.52"
+            },
+            "bin": [
+                "bin/jp.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.9-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/JmesPath.php"
+                ],
+                "psr-4": {
+                    "JmesPath\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Declaratively specify how to extract elements from a JSON document",
+            "keywords": [
+                "json",
+                "jsonpath"
+            ],
+            "support": {
+                "issues": "https://github.com/jmespath/jmespath.php/issues",
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.9.2"
+            },
+            "time": "2026-07-06T18:56:19+00:00"
         },
         {
             "name": "nesbot/carbon",
@@ -3805,6 +4183,77 @@
                 }
             ],
             "time": "2026-01-05T13:30:16+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/99aec13b82b4967ec5088222c4a3ecca955949c2",
+                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v8.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/finder",
@@ -10970,77 +11419,6 @@
                 }
             ],
             "time": "2024-10-20T05:08:20+00:00"
-        },
-        {
-            "name": "symfony/filesystem",
-            "version": "v8.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/filesystem.git",
-                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/99aec13b82b4967ec5088222c4a3ecca955949c2",
-                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.4.1",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-mbstring": "~1.8"
-            },
-            "require-dev": {
-                "symfony/process": "^7.4|^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Filesystem\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides basic utilities for the filesystem",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v8.1.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/options-resolver",

--- a/resources/js/react/components/ai/ContentAnalyzer.tsx
+++ b/resources/js/react/components/ai/ContentAnalyzer.tsx
@@ -1,0 +1,126 @@
+/**
+ * React trigger for the ContentAnalysisAgent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.2.0
+ */
+
+import type { FC } from 'react';
+
+import { useAiAgent } from '../../hooks/useAiAgent';
+import type { UseApiOptions } from '../../hooks/useApi';
+
+interface ContentAnalysisInput {
+	content: string;
+	primary_keyword: string;
+	secondary_keywords?: string[];
+}
+
+export interface DimensionScore {
+	score: number;
+	recommendations: string[];
+}
+
+export interface ContentAnalysisResult {
+	overall_score: number;
+	dimensions: {
+		keyword_usage: DimensionScore;
+		readability: DimensionScore;
+		structure: DimensionScore;
+		semantic_completeness: DimensionScore;
+	};
+}
+
+export interface ContentAnalyzerProps {
+	api: UseApiOptions;
+	content: string;
+	primaryKeyword: string;
+	secondaryKeywords?: string[];
+}
+
+const DIMENSION_LABELS: Record<keyof ContentAnalysisResult['dimensions'], string> = {
+	keyword_usage: 'Keyword usage',
+	readability: 'Readability',
+	structure: 'Structure',
+	semantic_completeness: 'Semantic completeness',
+};
+
+export const ContentAnalyzer: FC<ContentAnalyzerProps> = ( {
+	api,
+	content,
+	primaryKeyword,
+	secondaryKeywords,
+} ) => {
+	const { output, isLoading, error, run } = useAiAgent<ContentAnalysisInput, ContentAnalysisResult>(
+		'seo.analyze_content',
+		api,
+	);
+
+	const disabled = isLoading || content.trim() === '' || primaryKeyword.trim() === '';
+
+	const handleClick = (): void => {
+		void run( {
+			content,
+			primary_keyword: primaryKeyword,
+			secondary_keywords: secondaryKeywords,
+		} );
+	};
+
+	return (
+		<div className="seo-ai-analyzer" data-feature="seo.analyze_content">
+			<button
+				type="button"
+				onClick={ handleClick }
+				disabled={ disabled }
+				className="seo-ai-analyzer__button"
+			>
+				{ isLoading ? 'Analyzing…' : 'Analyze content' }
+			</button>
+
+			{ error && (
+				<p className="seo-ai-analyzer__error" role="alert">
+					{ error }
+				</p>
+			) }
+
+			{ output && (
+				<div className="seo-ai-analyzer__result">
+					<div className="seo-ai-analyzer__overall">
+						<span className="seo-ai-analyzer__overall-label">Overall score</span>
+						<span className="seo-ai-analyzer__overall-value">{ output.overall_score }/100</span>
+					</div>
+					<ul className="seo-ai-analyzer__dimensions">
+						{ ( Object.keys( DIMENSION_LABELS ) as Array<keyof typeof DIMENSION_LABELS> ).map(
+							( key ) => {
+								const dim = output.dimensions[key];
+								return (
+									<li key={ key } className="seo-ai-analyzer__dimension">
+										<div className="seo-ai-analyzer__dimension-header">
+											<span className="seo-ai-analyzer__dimension-name">
+												{ DIMENSION_LABELS[key] }
+											</span>
+											<span className="seo-ai-analyzer__dimension-score">
+												{ dim.score }/100
+											</span>
+										</div>
+										{ dim.recommendations.length > 0 && (
+											<ul className="seo-ai-analyzer__recommendations">
+												{ dim.recommendations.map( ( rec, idx ) => (
+													<li key={ idx }>{ rec }</li>
+												) ) }
+											</ul>
+										) }
+									</li>
+								);
+							},
+						) }
+					</ul>
+				</div>
+			) }
+		</div>
+	);
+};
+
+export default ContentAnalyzer;

--- a/resources/js/react/components/ai/HreflangSuggestor.tsx
+++ b/resources/js/react/components/ai/HreflangSuggestor.tsx
@@ -1,0 +1,116 @@
+/**
+ * React trigger for the HreflangSuggestionAgent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.2.0
+ */
+
+import type { FC } from 'react';
+
+import { useAiAgent } from '../../hooks/useAiAgent';
+import type { UseApiOptions } from '../../hooks/useApi';
+
+export interface HreflangTranslation {
+	url: string;
+	lang: string;
+}
+
+export interface HreflangPage {
+	url: string;
+	lang: string;
+	translations: HreflangTranslation[];
+}
+
+export interface HreflangIssue {
+	page_url: string;
+	issue_type: string;
+	suggested_hreflang: HreflangTranslation[];
+}
+
+interface HreflangInput {
+	pages: HreflangPage[];
+}
+
+interface HreflangOutput {
+	issues: HreflangIssue[];
+}
+
+export interface HreflangSuggestorProps {
+	api: UseApiOptions;
+	pages: HreflangPage[];
+	onApplyFix: ( issue: HreflangIssue ) => void;
+}
+
+export const HreflangSuggestor: FC<HreflangSuggestorProps> = ( {
+	api,
+	pages,
+	onApplyFix,
+} ) => {
+	const { output, isLoading, error, run } = useAiAgent<HreflangInput, HreflangOutput>(
+		'seo.suggest_hreflang',
+		api,
+	);
+
+	const disabled = isLoading || pages.length === 0;
+
+	const handleClick = (): void => {
+		void run( { pages } );
+	};
+
+	return (
+		<div className="seo-ai-suggestor" data-feature="seo.suggest_hreflang">
+			<button
+				type="button"
+				onClick={ handleClick }
+				disabled={ disabled }
+				className="seo-ai-suggestor__button"
+			>
+				{ isLoading ? 'Analyzing…' : 'Check hreflang' }
+			</button>
+
+			{ error && (
+				<p className="seo-ai-suggestor__error" role="alert">
+					{ error }
+				</p>
+			) }
+
+			{ output && output.issues.length > 0 && (
+				<ul className="seo-ai-suggestor__issues">
+					{ output.issues.map( ( issue, index ) => (
+						<li key={ index } className="seo-ai-suggestor__issue">
+							<div className="seo-ai-suggestor__issue-header">
+								<code>{ issue.page_url }</code>
+								<span className="seo-ai-suggestor__issue-type">{ issue.issue_type }</span>
+							</div>
+							{ issue.suggested_hreflang.length > 0 && (
+								<ul className="seo-ai-suggestor__hreflang">
+									{ issue.suggested_hreflang.map( ( entry, entryIdx ) => (
+										<li key={ entryIdx }>
+											<strong>{ entry.lang }</strong>
+											<code>{ entry.url }</code>
+										</li>
+									) ) }
+								</ul>
+							) }
+							<button
+								type="button"
+								onClick={ () => onApplyFix( issue ) }
+								className="seo-ai-suggestor__variant-apply"
+							>
+								Apply suggested tags
+							</button>
+						</li>
+					) ) }
+				</ul>
+			) }
+
+			{ output && output.issues.length === 0 && ! isLoading && ! error && (
+				<p className="seo-ai-suggestor__empty">No hreflang issues detected.</p>
+			) }
+		</div>
+	);
+};
+
+export default HreflangSuggestor;

--- a/resources/js/react/components/ai/MetaDescriptionSuggestor.tsx
+++ b/resources/js/react/components/ai/MetaDescriptionSuggestor.tsx
@@ -1,0 +1,91 @@
+/**
+ * React trigger for the MetaDescriptionAgent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.2.0
+ */
+
+import type { FC } from 'react';
+
+import { useAiAgent } from '../../hooks/useAiAgent';
+import type { UseApiOptions } from '../../hooks/useApi';
+
+interface MetaDescriptionInput {
+	content: string;
+	primary_keyword?: string;
+}
+
+export interface MetaDescriptionSuggestion {
+	meta_description: string;
+	character_count: number;
+	rationale: string;
+}
+
+export interface MetaDescriptionSuggestorProps {
+	api: UseApiOptions;
+	content: string;
+	primaryKeyword?: string;
+	onAccept: ( description: string ) => void;
+}
+
+export const MetaDescriptionSuggestor: FC<MetaDescriptionSuggestorProps> = ( {
+	api,
+	content,
+	primaryKeyword,
+	onAccept,
+} ) => {
+	const { output, isLoading, error, run } = useAiAgent<MetaDescriptionInput, MetaDescriptionSuggestion>(
+		'seo.suggest_meta_description',
+		api,
+	);
+
+	const disabled = isLoading || content.trim() === '';
+
+	const handleClick = (): void => {
+		void run( { content, primary_keyword: primaryKeyword } );
+	};
+
+	return (
+		<div className="seo-ai-suggestor" data-feature="seo.suggest_meta_description">
+			<button
+				type="button"
+				onClick={ handleClick }
+				disabled={ disabled }
+				className="seo-ai-suggestor__button"
+			>
+				{ isLoading ? 'Generating…' : 'Suggest meta description' }
+			</button>
+
+			{ error && (
+				<p className="seo-ai-suggestor__error" role="alert">
+					{ error }
+				</p>
+			) }
+
+			{ output && output.meta_description !== '' && (
+				<div className="seo-ai-suggestor__suggestion">
+					<p className="seo-ai-suggestor__suggestion-text">{ output.meta_description }</p>
+					<div className="seo-ai-suggestor__suggestion-meta">
+						<span className="seo-ai-suggestor__suggestion-count">
+							{ output.character_count }/160
+						</span>
+						{ output.rationale && (
+							<span className="seo-ai-suggestor__suggestion-rationale">{ output.rationale }</span>
+						) }
+					</div>
+					<button
+						type="button"
+						onClick={ () => onAccept( output.meta_description ) }
+						className="seo-ai-suggestor__variant-apply"
+					>
+						Use this description
+					</button>
+				</div>
+			) }
+		</div>
+	);
+};
+
+export default MetaDescriptionSuggestor;

--- a/resources/js/react/components/ai/MetaTitleSuggestor.tsx
+++ b/resources/js/react/components/ai/MetaTitleSuggestor.tsx
@@ -1,0 +1,114 @@
+/**
+ * React trigger for the MetaTitleSuggestionAgent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.2.0
+ */
+
+import type { FC } from 'react';
+
+import { useAiAgent } from '../../hooks/useAiAgent';
+import type { UseApiOptions } from '../../hooks/useApi';
+
+export interface TitleVariant {
+	title: string;
+	char_count: number;
+	rationale: string;
+}
+
+interface MetaTitleSuggestorInput {
+	content: string;
+	primary_keyword?: string;
+	brand?: string;
+}
+
+interface MetaTitleSuggestorOutput {
+	variants: TitleVariant[];
+}
+
+export interface MetaTitleSuggestorProps {
+	/** API configuration passed through to useApi. */
+	api: UseApiOptions;
+	/** Page content the agent should operate on. */
+	content: string;
+	/** Optional primary keyword. */
+	primaryKeyword?: string;
+	/** Optional brand suffix. */
+	brand?: string;
+	/** Called when the user picks a variant. */
+	onSelect: ( title: string ) => void;
+}
+
+/**
+ * Button + variant picker that runs the meta title suggestion agent.
+ */
+export const MetaTitleSuggestor: FC<MetaTitleSuggestorProps> = ( {
+	api,
+	content,
+	primaryKeyword,
+	brand,
+	onSelect,
+} ) => {
+	const { output, isLoading, error, run } = useAiAgent<MetaTitleSuggestorInput, MetaTitleSuggestorOutput>(
+		'seo.suggest_meta_title',
+		api,
+	);
+
+	const disabled = isLoading || content.trim() === '';
+
+	const handleClick = (): void => {
+		void run( {
+			content,
+			primary_keyword: primaryKeyword,
+			brand,
+		} );
+	};
+
+	return (
+		<div className="seo-ai-suggestor" data-feature="seo.suggest_meta_title">
+			<button
+				type="button"
+				onClick={ handleClick }
+				disabled={ disabled }
+				className="seo-ai-suggestor__button"
+			>
+				{ isLoading ? 'Generating…' : 'Suggest titles' }
+			</button>
+
+			{ error && (
+				<p className="seo-ai-suggestor__error" role="alert">
+					{ error }
+				</p>
+			) }
+
+			{ output && output.variants.length > 0 && (
+				<ul className="seo-ai-suggestor__variants">
+					{ output.variants.map( ( variant, index ) => (
+						<li key={ index } className="seo-ai-suggestor__variant">
+							<div className="seo-ai-suggestor__variant-header">
+								<strong className="seo-ai-suggestor__variant-title">{ variant.title }</strong>
+								<span className="seo-ai-suggestor__variant-count">
+									{ variant.char_count }/60
+								</span>
+							</div>
+							{ variant.rationale && (
+								<p className="seo-ai-suggestor__variant-rationale">{ variant.rationale }</p>
+							) }
+							<button
+								type="button"
+								onClick={ () => onSelect( variant.title ) }
+								className="seo-ai-suggestor__variant-apply"
+							>
+								Use this title
+							</button>
+						</li>
+					) ) }
+				</ul>
+			) }
+		</div>
+	);
+};
+
+export default MetaTitleSuggestor;

--- a/resources/js/react/components/ai/SchemaSuggestor.tsx
+++ b/resources/js/react/components/ai/SchemaSuggestor.tsx
@@ -1,0 +1,105 @@
+/**
+ * React trigger for the SchemaGenerationAgent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.2.0
+ */
+
+import type { FC } from 'react';
+
+import { useAiAgent } from '../../hooks/useAiAgent';
+import type { UseApiOptions } from '../../hooks/useApi';
+
+interface SchemaInput {
+	content: string;
+	title: string;
+	url?: string;
+}
+
+export interface SchemaSuggestion {
+	suggested_type: string;
+	confidence: number;
+	jsonld: Record<string, unknown>;
+	missing_required_fields: string[];
+}
+
+export interface SchemaSuggestorProps {
+	api: UseApiOptions;
+	content: string;
+	title: string;
+	url?: string;
+	onAccept: ( suggestion: SchemaSuggestion ) => void;
+}
+
+export const SchemaSuggestor: FC<SchemaSuggestorProps> = ( {
+	api,
+	content,
+	title,
+	url,
+	onAccept,
+} ) => {
+	const { output, isLoading, error, run } = useAiAgent<SchemaInput, SchemaSuggestion>(
+		'seo.generate_schema',
+		api,
+	);
+
+	const disabled = isLoading || content.trim() === '' || title.trim() === '';
+
+	const handleClick = (): void => {
+		void run( { content, title, url } );
+	};
+
+	return (
+		<div className="seo-ai-suggestor" data-feature="seo.generate_schema">
+			<button
+				type="button"
+				onClick={ handleClick }
+				disabled={ disabled }
+				className="seo-ai-suggestor__button"
+			>
+				{ isLoading ? 'Generating…' : 'Suggest schema' }
+			</button>
+
+			{ error && (
+				<p className="seo-ai-suggestor__error" role="alert">
+					{ error }
+				</p>
+			) }
+
+			{ output && (
+				<div className="seo-ai-suggestor__suggestion">
+					<div className="seo-ai-suggestor__suggestion-header">
+						<strong>{ output.suggested_type }</strong>
+						<span>
+							Confidence: { Math.round( output.confidence * 100 ) }%
+						</span>
+					</div>
+					<pre className="seo-ai-suggestor__jsonld">
+						<code>{ JSON.stringify( output.jsonld, null, 2 ) }</code>
+					</pre>
+					{ output.missing_required_fields.length > 0 && (
+						<div className="seo-ai-suggestor__missing">
+							<strong>Missing required fields:</strong>
+							<ul>
+								{ output.missing_required_fields.map( ( field, idx ) => (
+									<li key={ idx }>{ field }</li>
+								) ) }
+							</ul>
+						</div>
+					) }
+					<button
+						type="button"
+						onClick={ () => onAccept( output ) }
+						className="seo-ai-suggestor__variant-apply"
+					>
+						Populate schema builder
+					</button>
+				</div>
+			) }
+		</div>
+	);
+};
+
+export default SchemaSuggestor;

--- a/resources/js/react/components/ai/index.ts
+++ b/resources/js/react/components/ai/index.ts
@@ -1,0 +1,31 @@
+/**
+ * React AI trigger components barrel export.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.2.0
+ */
+
+export { MetaTitleSuggestor } from './MetaTitleSuggestor';
+export type { MetaTitleSuggestorProps, TitleVariant } from './MetaTitleSuggestor';
+
+export { MetaDescriptionSuggestor } from './MetaDescriptionSuggestor';
+export type {
+	MetaDescriptionSuggestorProps,
+	MetaDescriptionSuggestion,
+} from './MetaDescriptionSuggestor';
+
+export { ContentAnalyzer } from './ContentAnalyzer';
+export type { ContentAnalyzerProps, ContentAnalysisResult, DimensionScore } from './ContentAnalyzer';
+
+export { SchemaSuggestor } from './SchemaSuggestor';
+export type { SchemaSuggestorProps, SchemaSuggestion } from './SchemaSuggestor';
+
+export { HreflangSuggestor } from './HreflangSuggestor';
+export type {
+	HreflangSuggestorProps,
+	HreflangIssue,
+	HreflangPage,
+	HreflangTranslation,
+} from './HreflangSuggestor';

--- a/resources/js/react/hooks/useAiAgent.ts
+++ b/resources/js/react/hooks/useAiAgent.ts
@@ -1,0 +1,114 @@
+/**
+ * useAiAgent hook — thin wrapper over useApi for the SEO AI agent endpoints.
+ *
+ * Each of the five agents surfaces a POST endpoint under `/api/seo/ai/*`. This
+ * hook returns a typed dispatcher plus loading/error state so components stay
+ * free of boilerplate.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.2.0
+ */
+
+import { useCallback, useState } from 'react';
+
+import { ApiError, ApiValidationError, useApi, type UseApiOptions } from './useApi';
+
+/** Supported AI feature keys owned by the SEO package. */
+export type SeoAiFeatureKey =
+	| 'seo.suggest_meta_title'
+	| 'seo.suggest_meta_description'
+	| 'seo.analyze_content'
+	| 'seo.generate_schema'
+	| 'seo.suggest_hreflang';
+
+/** Map from feature key to the endpoint path segment (after `/ai/`). */
+const ENDPOINT_MAP: Record<SeoAiFeatureKey, string> = {
+	'seo.suggest_meta_title': '/ai/suggest-meta-title',
+	'seo.suggest_meta_description': '/ai/suggest-meta-description',
+	'seo.analyze_content': '/ai/analyze-content',
+	'seo.generate_schema': '/ai/generate-schema',
+	'seo.suggest_hreflang': '/ai/suggest-hreflang',
+};
+
+/** Envelope every agent endpoint returns. */
+export interface AgentResponse<TOutput> {
+	data: TOutput;
+	feature_key: SeoAiFeatureKey;
+}
+
+/** Return type of the useAiAgent hook. */
+export interface UseAiAgentReturn<TInput, TOutput> {
+	/** Latest successful output, or `null` before the first call. */
+	output: TOutput | null;
+	/** Whether a request is currently in flight. */
+	isLoading: boolean;
+	/** Latest error message, or `null` when the last run succeeded. */
+	error: string | null;
+	/** Dispatch a run against `input`. Returns the output on success. */
+	run: ( input: TInput ) => Promise<TOutput | null>;
+	/** Reset output/error to their initial values. */
+	reset: () => void;
+}
+
+/**
+ * React hook for dispatching a single SEO AI agent.
+ *
+ * @example
+ * ```tsx
+ * const { run, output, isLoading, error } = useAiAgent<TitleInput, TitleOutput>(
+ *   'seo.suggest_meta_title',
+ *   { baseUrl: '/api/seo' },
+ * );
+ * ```
+ */
+export function useAiAgent<TInput, TOutput>(
+	feature: SeoAiFeatureKey,
+	options: UseApiOptions,
+): UseAiAgentReturn<TInput, TOutput> {
+	const api = useApi( options );
+	const [output, setOutput] = useState<TOutput | null>( null );
+	const [isLoading, setIsLoading] = useState<boolean>( false );
+	const [error, setError] = useState<string | null>( null );
+
+	const reset = useCallback( () => {
+		setOutput( null );
+		setError( null );
+	}, [] );
+
+	const run = useCallback(
+		async ( input: TInput ): Promise<TOutput | null> => {
+			setIsLoading( true );
+			setError( null );
+
+			try {
+				const response = await api.post<AgentResponse<TOutput>>(
+					ENDPOINT_MAP[feature],
+					input,
+				);
+				setOutput( response.data );
+				return response.data;
+			} catch ( caught ) {
+				if ( caught instanceof ApiValidationError ) {
+					const firstField = Object.keys( caught.errors )[0];
+					const firstMessage = firstField ? caught.errors[firstField][0] : caught.message;
+					setError( firstMessage );
+				} else if ( caught instanceof ApiError ) {
+					setError( caught.message );
+				} else if ( caught instanceof Error ) {
+					setError( caught.message );
+				} else {
+					setError( 'Request failed.' );
+				}
+
+				return null;
+			} finally {
+				setIsLoading( false );
+			}
+		},
+		[api, feature],
+	);
+
+	return { output, isLoading, error, run, reset };
+}

--- a/resources/js/react/index.ts
+++ b/resources/js/react/index.ts
@@ -22,6 +22,9 @@ export {
 	useRedirects,
 } from './hooks';
 
+export { useAiAgent } from './hooks/useAiAgent';
+export type { SeoAiFeatureKey, UseAiAgentReturn, AgentResponse } from './hooks/useAiAgent';
+
 export type {
 	UseApiOptions,
 	UseApiReturn,
@@ -63,3 +66,28 @@ export type {
 	RedirectManagerProps,
 	SeoDashboardProps,
 } from './components/admin';
+
+// AI Trigger Components
+export {
+	MetaTitleSuggestor,
+	MetaDescriptionSuggestor,
+	ContentAnalyzer,
+	SchemaSuggestor,
+	HreflangSuggestor,
+} from './components/ai';
+
+export type {
+	MetaTitleSuggestorProps,
+	TitleVariant,
+	MetaDescriptionSuggestorProps,
+	MetaDescriptionSuggestion,
+	ContentAnalyzerProps,
+	ContentAnalysisResult,
+	DimensionScore,
+	SchemaSuggestorProps,
+	SchemaSuggestion,
+	HreflangSuggestorProps,
+	HreflangIssue,
+	HreflangPage,
+	HreflangTranslation,
+} from './components/ai';

--- a/resources/js/vue/components/ai/ContentAnalyzer.vue
+++ b/resources/js/vue/components/ai/ContentAnalyzer.vue
@@ -1,0 +1,134 @@
+<!--
+  Vue trigger for the ContentAnalysisAgent.
+
+  @package    ArtisanPack_UI
+  @subpackage SEO
+
+  @since      1.2.0
+-->
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+import { useAiAgent } from '../../composables/useAiAgent';
+import type { UseApiOptions } from '../../composables/useApi';
+
+interface Input {
+	content: string;
+	primary_keyword: string;
+	secondary_keywords?: string[];
+}
+
+export interface DimensionScore {
+	score: number;
+	recommendations: string[];
+}
+
+export interface ContentAnalysisResult {
+	overall_score: number;
+	dimensions: {
+		keyword_usage: DimensionScore;
+		readability: DimensionScore;
+		structure: DimensionScore;
+		semantic_completeness: DimensionScore;
+	};
+}
+
+const DIMENSION_LABELS: Record<keyof ContentAnalysisResult['dimensions'], string> = {
+	keyword_usage: 'Keyword usage',
+	readability: 'Readability',
+	structure: 'Structure',
+	semantic_completeness: 'Semantic completeness',
+};
+
+const DIMENSION_KEYS = Object.keys( DIMENSION_LABELS ) as Array<
+	keyof ContentAnalysisResult['dimensions']
+>;
+
+const props = withDefaults(
+	defineProps<{
+		api: UseApiOptions;
+		content: string;
+		primaryKeyword: string;
+		secondaryKeywords?: string[];
+	}>(),
+	{
+		secondaryKeywords: () => [],
+	},
+);
+
+const { output, isLoading, error, run } = useAiAgent<Input, ContentAnalysisResult>(
+	'seo.analyze_content',
+	props.api,
+);
+
+const disabled = computed(
+	() =>
+		isLoading.value ||
+		props.content.trim() === '' ||
+		props.primaryKeyword.trim() === '',
+);
+
+const handleClick = (): void => {
+	void run( {
+		content: props.content,
+		primary_keyword: props.primaryKeyword,
+		secondary_keywords: props.secondaryKeywords,
+	} );
+};
+</script>
+
+<template>
+	<div class="seo-ai-analyzer" data-feature="seo.analyze_content">
+		<button
+			type="button"
+			class="seo-ai-analyzer__button"
+			:disabled="disabled"
+			@click="handleClick"
+		>
+			<template v-if="isLoading">Analyzing…</template>
+			<template v-else>Analyze content</template>
+		</button>
+
+		<p v-if="error" class="seo-ai-analyzer__error" role="alert">
+			{{ error }}
+		</p>
+
+		<div v-if="output" class="seo-ai-analyzer__result">
+			<div class="seo-ai-analyzer__overall">
+				<span class="seo-ai-analyzer__overall-label">Overall score</span>
+				<span class="seo-ai-analyzer__overall-value">
+					{{ output.overall_score }}/100
+				</span>
+			</div>
+
+			<ul class="seo-ai-analyzer__dimensions">
+				<li
+					v-for="key in DIMENSION_KEYS"
+					:key="key"
+					class="seo-ai-analyzer__dimension"
+				>
+					<div class="seo-ai-analyzer__dimension-header">
+						<span class="seo-ai-analyzer__dimension-name">
+							{{ DIMENSION_LABELS[key] }}
+						</span>
+						<span class="seo-ai-analyzer__dimension-score">
+							{{ output.dimensions[key].score }}/100
+						</span>
+					</div>
+					<ul
+						v-if="output.dimensions[key].recommendations.length > 0"
+						class="seo-ai-analyzer__recommendations"
+					>
+						<li
+							v-for="( rec, index ) in output.dimensions[key].recommendations"
+							:key="index"
+						>
+							{{ rec }}
+						</li>
+					</ul>
+				</li>
+			</ul>
+		</div>
+	</div>
+</template>

--- a/resources/js/vue/components/ai/HreflangSuggestor.vue
+++ b/resources/js/vue/components/ai/HreflangSuggestor.vue
@@ -1,0 +1,120 @@
+<!--
+  Vue trigger for the HreflangSuggestionAgent.
+
+  @package    ArtisanPack_UI
+  @subpackage SEO
+
+  @since      1.2.0
+-->
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+import { useAiAgent } from '../../composables/useAiAgent';
+import type { UseApiOptions } from '../../composables/useApi';
+
+export interface HreflangTranslation {
+	url: string;
+	lang: string;
+}
+
+export interface HreflangPage {
+	url: string;
+	lang: string;
+	translations: HreflangTranslation[];
+}
+
+export interface HreflangIssue {
+	page_url: string;
+	issue_type: string;
+	suggested_hreflang: HreflangTranslation[];
+}
+
+interface Input {
+	pages: HreflangPage[];
+}
+
+interface Output {
+	issues: HreflangIssue[];
+}
+
+const props = defineProps<{
+	api: UseApiOptions;
+	pages: HreflangPage[];
+}>();
+
+const emit = defineEmits<{
+	( event: 'apply-fix', issue: HreflangIssue ): void;
+}>();
+
+const { output, isLoading, error, run } = useAiAgent<Input, Output>(
+	'seo.suggest_hreflang',
+	props.api,
+);
+
+const disabled = computed( () => isLoading.value || props.pages.length === 0 );
+
+const handleClick = (): void => {
+	void run( { pages: props.pages } );
+};
+</script>
+
+<template>
+	<div class="seo-ai-suggestor" data-feature="seo.suggest_hreflang">
+		<button
+			type="button"
+			class="seo-ai-suggestor__button"
+			:disabled="disabled"
+			@click="handleClick"
+		>
+			<template v-if="isLoading">Analyzing…</template>
+			<template v-else>Check hreflang</template>
+		</button>
+
+		<p v-if="error" class="seo-ai-suggestor__error" role="alert">
+			{{ error }}
+		</p>
+
+		<ul
+			v-if="output && output.issues.length > 0"
+			class="seo-ai-suggestor__issues"
+		>
+			<li
+				v-for="( issue, index ) in output.issues"
+				:key="index"
+				class="seo-ai-suggestor__issue"
+			>
+				<div class="seo-ai-suggestor__issue-header">
+					<code>{{ issue.page_url }}</code>
+					<span class="seo-ai-suggestor__issue-type">{{ issue.issue_type }}</span>
+				</div>
+				<ul
+					v-if="issue.suggested_hreflang.length > 0"
+					class="seo-ai-suggestor__hreflang"
+				>
+					<li
+						v-for="( entry, entryIndex ) in issue.suggested_hreflang"
+						:key="entryIndex"
+					>
+						<strong>{{ entry.lang }}</strong>
+						<code>{{ entry.url }}</code>
+					</li>
+				</ul>
+				<button
+					type="button"
+					class="seo-ai-suggestor__variant-apply"
+					@click="emit( 'apply-fix', issue )"
+				>
+					Apply suggested tags
+				</button>
+			</li>
+		</ul>
+
+		<p
+			v-else-if="output && output.issues.length === 0 && ! isLoading && ! error"
+			class="seo-ai-suggestor__empty"
+		>
+			No hreflang issues detected.
+		</p>
+	</div>
+</template>

--- a/resources/js/vue/components/ai/MetaDescriptionSuggestor.vue
+++ b/resources/js/vue/components/ai/MetaDescriptionSuggestor.vue
@@ -1,0 +1,100 @@
+<!--
+  Vue trigger for the MetaDescriptionAgent.
+
+  @package    ArtisanPack_UI
+  @subpackage SEO
+
+  @since      1.2.0
+-->
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+import { useAiAgent } from '../../composables/useAiAgent';
+import type { UseApiOptions } from '../../composables/useApi';
+
+interface Input {
+	content: string;
+	primary_keyword?: string;
+}
+
+export interface MetaDescriptionSuggestion {
+	meta_description: string;
+	character_count: number;
+	rationale: string;
+}
+
+const props = withDefaults(
+	defineProps<{
+		api: UseApiOptions;
+		content: string;
+		primaryKeyword?: string;
+	}>(),
+	{
+		primaryKeyword: '',
+	},
+);
+
+const emit = defineEmits<{
+	( event: 'accept', description: string ): void;
+}>();
+
+const { output, isLoading, error, run } = useAiAgent<Input, MetaDescriptionSuggestion>(
+	'seo.suggest_meta_description',
+	props.api,
+);
+
+const disabled = computed(
+	() => isLoading.value || props.content.trim() === '',
+);
+
+const handleClick = (): void => {
+	void run( {
+		content: props.content,
+		primary_keyword: props.primaryKeyword,
+	} );
+};
+</script>
+
+<template>
+	<div class="seo-ai-suggestor" data-feature="seo.suggest_meta_description">
+		<button
+			type="button"
+			class="seo-ai-suggestor__button"
+			:disabled="disabled"
+			@click="handleClick"
+		>
+			<template v-if="isLoading">Generating…</template>
+			<template v-else>Suggest meta description</template>
+		</button>
+
+		<p v-if="error" class="seo-ai-suggestor__error" role="alert">
+			{{ error }}
+		</p>
+
+		<div
+			v-if="output && output.meta_description !== ''"
+			class="seo-ai-suggestor__suggestion"
+		>
+			<p class="seo-ai-suggestor__suggestion-text">{{ output.meta_description }}</p>
+			<div class="seo-ai-suggestor__suggestion-meta">
+				<span class="seo-ai-suggestor__suggestion-count">
+					{{ output.character_count }}/160
+				</span>
+				<span
+					v-if="output.rationale"
+					class="seo-ai-suggestor__suggestion-rationale"
+				>
+					{{ output.rationale }}
+				</span>
+			</div>
+			<button
+				type="button"
+				class="seo-ai-suggestor__variant-apply"
+				@click="emit( 'accept', output.meta_description )"
+			>
+				Use this description
+			</button>
+		</div>
+	</div>
+</template>

--- a/resources/js/vue/components/ai/MetaTitleSuggestor.vue
+++ b/resources/js/vue/components/ai/MetaTitleSuggestor.vue
@@ -1,0 +1,112 @@
+<!--
+  Vue trigger for the MetaTitleSuggestionAgent.
+
+  @package    ArtisanPack_UI
+  @subpackage SEO
+
+  @since      1.2.0
+-->
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+import { useAiAgent } from '../../composables/useAiAgent';
+import type { UseApiOptions } from '../../composables/useApi';
+
+export interface TitleVariant {
+	title: string;
+	char_count: number;
+	rationale: string;
+}
+
+interface Input {
+	content: string;
+	primary_keyword?: string;
+	brand?: string;
+}
+
+interface Output {
+	variants: TitleVariant[];
+}
+
+const props = withDefaults(
+	defineProps<{
+		api: UseApiOptions;
+		content: string;
+		primaryKeyword?: string;
+		brand?: string;
+	}>(),
+	{
+		primaryKeyword: '',
+		brand: '',
+	},
+);
+
+const emit = defineEmits<{
+	( event: 'select', title: string ): void;
+}>();
+
+const { output, isLoading, error, run } = useAiAgent<Input, Output>(
+	'seo.suggest_meta_title',
+	props.api,
+);
+
+const disabled = computed(
+	() => isLoading.value || props.content.trim() === '',
+);
+
+const handleClick = (): void => {
+	void run( {
+		content: props.content,
+		primary_keyword: props.primaryKeyword,
+		brand: props.brand,
+	} );
+};
+</script>
+
+<template>
+	<div class="seo-ai-suggestor" data-feature="seo.suggest_meta_title">
+		<button
+			type="button"
+			class="seo-ai-suggestor__button"
+			:disabled="disabled"
+			@click="handleClick"
+		>
+			<template v-if="isLoading">Generating…</template>
+			<template v-else>Suggest titles</template>
+		</button>
+
+		<p v-if="error" class="seo-ai-suggestor__error" role="alert">
+			{{ error }}
+		</p>
+
+		<ul
+			v-if="output && output.variants.length > 0"
+			class="seo-ai-suggestor__variants"
+		>
+			<li
+				v-for="( variant, index ) in output.variants"
+				:key="index"
+				class="seo-ai-suggestor__variant"
+			>
+				<div class="seo-ai-suggestor__variant-header">
+					<strong class="seo-ai-suggestor__variant-title">{{ variant.title }}</strong>
+					<span class="seo-ai-suggestor__variant-count">{{ variant.char_count }}/60</span>
+				</div>
+				<p
+					v-if="variant.rationale"
+					class="seo-ai-suggestor__variant-rationale"
+				>
+					{{ variant.rationale }}
+				</p>
+				<button
+					type="button"
+					class="seo-ai-suggestor__variant-apply"
+					@click="emit( 'select', variant.title )"
+				>
+					Use this title
+				</button>
+			</li>
+		</ul>
+	</div>
+</template>

--- a/resources/js/vue/components/ai/SchemaSuggestor.vue
+++ b/resources/js/vue/components/ai/SchemaSuggestor.vue
@@ -1,0 +1,115 @@
+<!--
+  Vue trigger for the SchemaGenerationAgent.
+
+  @package    ArtisanPack_UI
+  @subpackage SEO
+
+  @since      1.2.0
+-->
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+import { useAiAgent } from '../../composables/useAiAgent';
+import type { UseApiOptions } from '../../composables/useApi';
+
+interface Input {
+	content: string;
+	title: string;
+	url?: string;
+}
+
+export interface SchemaSuggestion {
+	suggested_type: string;
+	confidence: number;
+	jsonld: Record<string, unknown>;
+	missing_required_fields: string[];
+}
+
+const props = withDefaults(
+	defineProps<{
+		api: UseApiOptions;
+		content: string;
+		title: string;
+		url?: string;
+	}>(),
+	{
+		url: '',
+	},
+);
+
+const emit = defineEmits<{
+	( event: 'accept', suggestion: SchemaSuggestion ): void;
+}>();
+
+const { output, isLoading, error, run } = useAiAgent<Input, SchemaSuggestion>(
+	'seo.generate_schema',
+	props.api,
+);
+
+const disabled = computed(
+	() =>
+		isLoading.value ||
+		props.content.trim() === '' ||
+		props.title.trim() === '',
+);
+
+const handleClick = (): void => {
+	void run( { content: props.content, title: props.title, url: props.url } );
+};
+
+const jsonldFormatted = computed( () =>
+	output.value ? JSON.stringify( output.value.jsonld, null, 2 ) : '',
+);
+
+const confidencePercent = computed( () =>
+	output.value ? Math.round( output.value.confidence * 100 ) : 0,
+);
+</script>
+
+<template>
+	<div class="seo-ai-suggestor" data-feature="seo.generate_schema">
+		<button
+			type="button"
+			class="seo-ai-suggestor__button"
+			:disabled="disabled"
+			@click="handleClick"
+		>
+			<template v-if="isLoading">Generating…</template>
+			<template v-else>Suggest schema</template>
+		</button>
+
+		<p v-if="error" class="seo-ai-suggestor__error" role="alert">
+			{{ error }}
+		</p>
+
+		<div v-if="output" class="seo-ai-suggestor__suggestion">
+			<div class="seo-ai-suggestor__suggestion-header">
+				<strong>{{ output.suggested_type }}</strong>
+				<span>Confidence: {{ confidencePercent }}%</span>
+			</div>
+			<pre class="seo-ai-suggestor__jsonld"><code>{{ jsonldFormatted }}</code></pre>
+			<div
+				v-if="output.missing_required_fields.length > 0"
+				class="seo-ai-suggestor__missing"
+			>
+				<strong>Missing required fields:</strong>
+				<ul>
+					<li
+						v-for="( field, index ) in output.missing_required_fields"
+						:key="index"
+					>
+						{{ field }}
+					</li>
+				</ul>
+			</div>
+			<button
+				type="button"
+				class="seo-ai-suggestor__variant-apply"
+				@click="emit( 'accept', output )"
+			>
+				Populate schema builder
+			</button>
+		</div>
+	</div>
+</template>

--- a/resources/js/vue/components/ai/index.ts
+++ b/resources/js/vue/components/ai/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Vue AI trigger components barrel export.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.2.0
+ */
+
+export { default as MetaTitleSuggestor } from './MetaTitleSuggestor.vue';
+export { default as MetaDescriptionSuggestor } from './MetaDescriptionSuggestor.vue';
+export { default as ContentAnalyzer } from './ContentAnalyzer.vue';
+export { default as SchemaSuggestor } from './SchemaSuggestor.vue';
+export { default as HreflangSuggestor } from './HreflangSuggestor.vue';

--- a/resources/js/vue/composables/useAiAgent.ts
+++ b/resources/js/vue/composables/useAiAgent.ts
@@ -1,0 +1,92 @@
+/**
+ * useAiAgent composable — thin wrapper over useApi for the SEO AI endpoints.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.2.0
+ */
+
+import { ref, type Ref } from 'vue';
+
+import { ApiError, ApiValidationError, useApi, type UseApiOptions } from './useApi';
+
+/** Supported AI feature keys owned by the SEO package. */
+export type SeoAiFeatureKey =
+	| 'seo.suggest_meta_title'
+	| 'seo.suggest_meta_description'
+	| 'seo.analyze_content'
+	| 'seo.generate_schema'
+	| 'seo.suggest_hreflang';
+
+const ENDPOINT_MAP: Record<SeoAiFeatureKey, string> = {
+	'seo.suggest_meta_title': '/ai/suggest-meta-title',
+	'seo.suggest_meta_description': '/ai/suggest-meta-description',
+	'seo.analyze_content': '/ai/analyze-content',
+	'seo.generate_schema': '/ai/generate-schema',
+	'seo.suggest_hreflang': '/ai/suggest-hreflang',
+};
+
+/** Envelope every agent endpoint returns. */
+export interface AgentResponse<TOutput> {
+	data: TOutput;
+	feature_key: SeoAiFeatureKey;
+}
+
+/** Return type of the useAiAgent composable. */
+export interface UseAiAgentReturn<TInput, TOutput> {
+	output: Ref<TOutput | null>;
+	isLoading: Ref<boolean>;
+	error: Ref<string | null>;
+	run: ( input: TInput ) => Promise<TOutput | null>;
+	reset: () => void;
+}
+
+/**
+ * Vue composable for dispatching a single SEO AI agent.
+ */
+export function useAiAgent<TInput, TOutput>(
+	feature: SeoAiFeatureKey,
+	options: UseApiOptions,
+): UseAiAgentReturn<TInput, TOutput> {
+	const api = useApi( options );
+	const output = ref<TOutput | null>( null ) as Ref<TOutput | null>;
+	const isLoading = ref<boolean>( false );
+	const error = ref<string | null>( null );
+
+	const reset = (): void => {
+		output.value = null;
+		error.value = null;
+	};
+
+	const run = async ( input: TInput ): Promise<TOutput | null> => {
+		isLoading.value = true;
+		error.value = null;
+
+		try {
+			const response = await api.post<AgentResponse<TOutput>>(
+				ENDPOINT_MAP[feature],
+				input,
+			);
+			output.value = response.data;
+			return response.data;
+		} catch ( caught ) {
+			if ( caught instanceof ApiValidationError ) {
+				const firstField = Object.keys( caught.errors )[0];
+				error.value = firstField ? caught.errors[firstField][0] : caught.message;
+			} else if ( caught instanceof ApiError ) {
+				error.value = caught.message;
+			} else if ( caught instanceof Error ) {
+				error.value = caught.message;
+			} else {
+				error.value = 'Request failed.';
+			}
+
+			return null;
+		} finally {
+			isLoading.value = false;
+		}
+	};
+
+	return { output, isLoading, error, run, reset };
+}

--- a/resources/js/vue/index.ts
+++ b/resources/js/vue/index.ts
@@ -33,6 +33,9 @@ export type {
 	PaginatedRedirects,
 } from './composables';
 
+export { useAiAgent } from './composables/useAiAgent';
+export type { SeoAiFeatureKey, UseAiAgentReturn, AgentResponse } from './composables/useAiAgent';
+
 // Admin Components
 export {
 	BasicMetaTab,
@@ -48,3 +51,12 @@ export {
 	RedirectManager,
 	SeoDashboard,
 } from './components/admin';
+
+// AI Trigger Components
+export {
+	MetaTitleSuggestor,
+	MetaDescriptionSuggestor,
+	ContentAnalyzer,
+	SchemaSuggestor,
+	HreflangSuggestor,
+} from './components/ai';

--- a/resources/views/livewire/ai/content-analyzer.blade.php
+++ b/resources/views/livewire/ai/content-analyzer.blade.php
@@ -1,0 +1,59 @@
+<div class="seo-ai-analyzer" data-feature="seo.analyze_content">
+	@if ( ! $this->isEnabled )
+		<p class="seo-ai-analyzer__disabled">
+			{{ __( 'AI content analysis is currently disabled.' ) }}
+		</p>
+	@else
+		<button
+			type="button"
+			wire:click="analyze"
+			wire:loading.attr="disabled"
+			wire:target="analyze"
+			@disabled( $isLoading || '' === trim( $content ) || '' === trim( $primaryKeyword ) )
+			class="seo-ai-analyzer__button"
+		>
+			<span wire:loading.remove wire:target="analyze">
+				{{ __( 'Analyze content' ) }}
+			</span>
+			<span wire:loading wire:target="analyze">
+				{{ __( 'Analyzing…' ) }}
+			</span>
+		</button>
+
+		@if ( null !== $error )
+			<p class="seo-ai-analyzer__error" role="alert">
+				{{ $error }}
+			</p>
+		@endif
+
+		@if ( null !== $overallScore )
+			<div class="seo-ai-analyzer__result">
+				<div class="seo-ai-analyzer__overall">
+					<span class="seo-ai-analyzer__overall-label">{{ __( 'Overall score' ) }}</span>
+					<span class="seo-ai-analyzer__overall-value">{{ $overallScore }}/100</span>
+				</div>
+
+				<ul class="seo-ai-analyzer__dimensions">
+					@foreach ( $dimensions as $key => $dimension )
+						<li class="seo-ai-analyzer__dimension" wire:key="dim-{{ $key }}">
+							<div class="seo-ai-analyzer__dimension-header">
+								<span class="seo-ai-analyzer__dimension-name">
+									{{ __( ucwords( str_replace( '_', ' ', (string) $key ) ) ) }}
+								</span>
+								<span class="seo-ai-analyzer__dimension-score">{{ $dimension['score'] }}/100</span>
+							</div>
+
+							@if ( ! empty( $dimension['recommendations'] ) )
+								<ul class="seo-ai-analyzer__recommendations">
+									@foreach ( $dimension['recommendations'] as $recIndex => $recommendation )
+										<li wire:key="rec-{{ $key }}-{{ $recIndex }}">{{ $recommendation }}</li>
+									@endforeach
+								</ul>
+							@endif
+						</li>
+					@endforeach
+				</ul>
+			</div>
+		@endif
+	@endif
+</div>

--- a/resources/views/livewire/ai/hreflang-suggestor.blade.php
+++ b/resources/views/livewire/ai/hreflang-suggestor.blade.php
@@ -1,0 +1,65 @@
+<div class="seo-ai-suggestor" data-feature="seo.suggest_hreflang">
+	@if ( ! $this->isEnabled )
+		<p class="seo-ai-suggestor__disabled">
+			{{ __( 'AI hreflang suggestions are currently disabled.' ) }}
+		</p>
+	@else
+		<button
+			type="button"
+			wire:click="suggest"
+			wire:loading.attr="disabled"
+			wire:target="suggest"
+			@disabled( $isLoading || empty( $pages ) )
+			class="seo-ai-suggestor__button"
+		>
+			<span wire:loading.remove wire:target="suggest">
+				{{ __( 'Check hreflang' ) }}
+			</span>
+			<span wire:loading wire:target="suggest">
+				{{ __( 'Analyzing…' ) }}
+			</span>
+		</button>
+
+		@if ( null !== $error )
+			<p class="seo-ai-suggestor__error" role="alert">
+				{{ $error }}
+			</p>
+		@endif
+
+		@if ( ! empty( $issues ) )
+			<ul class="seo-ai-suggestor__issues">
+				@foreach ( $issues as $index => $issue )
+					<li class="seo-ai-suggestor__issue" wire:key="hreflang-issue-{{ $index }}">
+						<div class="seo-ai-suggestor__issue-header">
+							<code>{{ $issue['page_url'] }}</code>
+							<span class="seo-ai-suggestor__issue-type">{{ $issue['issue_type'] }}</span>
+						</div>
+
+						@if ( ! empty( $issue['suggested_hreflang'] ) )
+							<ul class="seo-ai-suggestor__hreflang">
+								@foreach ( $issue['suggested_hreflang'] as $entryIndex => $entry )
+									<li wire:key="hreflang-{{ $index }}-{{ $entryIndex }}">
+										<strong>{{ $entry['lang'] }}</strong>
+										<code>{{ $entry['url'] }}</code>
+									</li>
+								@endforeach
+							</ul>
+						@endif
+
+						<button
+							type="button"
+							wire:click="applyFix({{ $index }})"
+							class="seo-ai-suggestor__variant-apply"
+						>
+							{{ __( 'Apply suggested tags' ) }}
+						</button>
+					</li>
+				@endforeach
+			</ul>
+		@elseif ( ! $isLoading && null === $error )
+			<p class="seo-ai-suggestor__empty">
+				{{ __( 'Run the check to look for missing hreflang tags.' ) }}
+			</p>
+		@endif
+	@endif
+</div>

--- a/resources/views/livewire/ai/meta-description-suggestor.blade.php
+++ b/resources/views/livewire/ai/meta-description-suggestor.blade.php
@@ -1,0 +1,48 @@
+<div class="seo-ai-suggestor" data-feature="seo.suggest_meta_description">
+	@if ( ! $this->isEnabled )
+		<p class="seo-ai-suggestor__disabled">
+			{{ __( 'AI meta description suggestions are currently disabled.' ) }}
+		</p>
+	@else
+		<button
+			type="button"
+			wire:click="suggest"
+			wire:loading.attr="disabled"
+			wire:target="suggest"
+			@disabled( $isLoading || '' === trim( $content ) )
+			class="seo-ai-suggestor__button"
+		>
+			<span wire:loading.remove wire:target="suggest">
+				{{ __( 'Suggest meta description' ) }}
+			</span>
+			<span wire:loading wire:target="suggest">
+				{{ __( 'Generating…' ) }}
+			</span>
+		</button>
+
+		@if ( null !== $error )
+			<p class="seo-ai-suggestor__error" role="alert">
+				{{ $error }}
+			</p>
+		@endif
+
+		@if ( null !== $suggestion )
+			<div class="seo-ai-suggestor__suggestion">
+				<p class="seo-ai-suggestor__suggestion-text">{{ $suggestion }}</p>
+				<div class="seo-ai-suggestor__suggestion-meta">
+					<span class="seo-ai-suggestor__suggestion-count">{{ $characterCount }}/160</span>
+					@if ( '' !== $rationale )
+						<span class="seo-ai-suggestor__suggestion-rationale">{{ $rationale }}</span>
+					@endif
+				</div>
+				<button
+					type="button"
+					wire:click="accept"
+					class="seo-ai-suggestor__variant-apply"
+				>
+					{{ __( 'Use this description' ) }}
+				</button>
+			</div>
+		@endif
+	@endif
+</div>

--- a/resources/views/livewire/ai/meta-title-suggestor.blade.php
+++ b/resources/views/livewire/ai/meta-title-suggestor.blade.php
@@ -1,0 +1,56 @@
+<div class="seo-ai-suggestor" data-feature="seo.suggest_meta_title">
+	@if ( ! $this->isEnabled )
+		<p class="seo-ai-suggestor__disabled">
+			{{ __( 'AI title suggestions are currently disabled.' ) }}
+		</p>
+	@else
+		<button
+			type="button"
+			wire:click="suggest"
+			wire:loading.attr="disabled"
+			wire:target="suggest"
+			@disabled( $isLoading || '' === trim( $content ) )
+			class="seo-ai-suggestor__button"
+		>
+			<span wire:loading.remove wire:target="suggest">
+				{{ __( 'Suggest titles' ) }}
+			</span>
+			<span wire:loading wire:target="suggest">
+				{{ __( 'Generating…' ) }}
+			</span>
+		</button>
+
+		@if ( null !== $error )
+			<p class="seo-ai-suggestor__error" role="alert">
+				{{ $error }}
+			</p>
+		@endif
+
+		@if ( ! empty( $variants ) )
+			<ul class="seo-ai-suggestor__variants">
+				@foreach ( $variants as $index => $variant )
+					<li class="seo-ai-suggestor__variant" wire:key="title-variant-{{ $index }}">
+						<div class="seo-ai-suggestor__variant-header">
+							<strong class="seo-ai-suggestor__variant-title">{{ $variant['title'] }}</strong>
+							<span class="seo-ai-suggestor__variant-count">
+								{{ $variant['char_count'] }}/60
+							</span>
+						</div>
+
+						@if ( ! empty( $variant['rationale'] ) )
+							<p class="seo-ai-suggestor__variant-rationale">{{ $variant['rationale'] }}</p>
+						@endif
+
+						<button
+							type="button"
+							wire:click="select({{ $index }})"
+							class="seo-ai-suggestor__variant-apply"
+						>
+							{{ __( 'Use this title' ) }}
+						</button>
+					</li>
+				@endforeach
+			</ul>
+		@endif
+	@endif
+</div>

--- a/resources/views/livewire/ai/schema-suggestor.blade.php
+++ b/resources/views/livewire/ai/schema-suggestor.blade.php
@@ -1,0 +1,59 @@
+<div class="seo-ai-suggestor" data-feature="seo.generate_schema">
+	@if ( ! $this->isEnabled )
+		<p class="seo-ai-suggestor__disabled">
+			{{ __( 'AI schema suggestions are currently disabled.' ) }}
+		</p>
+	@else
+		<button
+			type="button"
+			wire:click="suggest"
+			wire:loading.attr="disabled"
+			wire:target="suggest"
+			@disabled( $isLoading || '' === trim( $content ) || '' === trim( $title ) )
+			class="seo-ai-suggestor__button"
+		>
+			<span wire:loading.remove wire:target="suggest">
+				{{ __( 'Suggest schema' ) }}
+			</span>
+			<span wire:loading wire:target="suggest">
+				{{ __( 'Generating…' ) }}
+			</span>
+		</button>
+
+		@if ( null !== $error )
+			<p class="seo-ai-suggestor__error" role="alert">
+				{{ $error }}
+			</p>
+		@endif
+
+		@if ( null !== $suggestedType )
+			<div class="seo-ai-suggestor__suggestion">
+				<div class="seo-ai-suggestor__suggestion-header">
+					<strong>{{ $suggestedType }}</strong>
+					<span>{{ __( 'Confidence' ) }}: {{ number_format( $confidence * 100, 0 ) }}%</span>
+				</div>
+
+				<pre class="seo-ai-suggestor__jsonld"><code>{{ json_encode( $jsonld, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) }}</code></pre>
+
+				@if ( ! empty( $missingRequiredFields ) )
+					<div class="seo-ai-suggestor__missing">
+						<strong>{{ __( 'Missing required fields:' ) }}</strong>
+						<ul>
+							@foreach ( $missingRequiredFields as $field )
+								<li>{{ $field }}</li>
+							@endforeach
+						</ul>
+					</div>
+				@endif
+
+				<button
+					type="button"
+					wire:click="accept"
+					class="seo-ai-suggestor__variant-apply"
+				>
+					{{ __( 'Populate schema builder' ) }}
+				</button>
+			</div>
+		@endif
+	@endif
+</div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,6 +13,7 @@
 
 declare( strict_types=1 );
 
+use ArtisanPackUI\SEO\Http\Controllers\Api\AiAgentApiController;
 use ArtisanPackUI\SEO\Http\Controllers\Api\AnalysisApiController;
 use ArtisanPackUI\SEO\Http\Controllers\Api\RedirectApiController;
 use ArtisanPackUI\SEO\Http\Controllers\Api\SchemaApiController;
@@ -85,6 +86,24 @@ if ( true === config( 'seo.api.enabled', true ) ) {
 
 				Route::delete( '{redirect}', [ RedirectApiController::class, 'destroy' ] )
 					->name( 'seo.api.redirects.destroy' );
+			} );
+
+			// AI agent endpoints
+			Route::prefix( 'ai' )->group( function (): void {
+				Route::post( 'suggest-meta-title', [ AiAgentApiController::class, 'suggestMetaTitle' ] )
+					->name( 'seo.api.ai.suggest-meta-title' );
+
+				Route::post( 'suggest-meta-description', [ AiAgentApiController::class, 'suggestMetaDescription' ] )
+					->name( 'seo.api.ai.suggest-meta-description' );
+
+				Route::post( 'analyze-content', [ AiAgentApiController::class, 'analyzeContent' ] )
+					->name( 'seo.api.ai.analyze-content' );
+
+				Route::post( 'generate-schema', [ AiAgentApiController::class, 'generateSchema' ] )
+					->name( 'seo.api.ai.generate-schema' );
+
+				Route::post( 'suggest-hreflang', [ AiAgentApiController::class, 'suggestHreflang' ] )
+					->name( 'seo.api.ai.suggest-hreflang' );
 			} );
 
 			// Schema endpoints

--- a/src/Ai/Agents/ContentAnalysisAgent.php
+++ b/src/Ai/Agents/ContentAnalysisAgent.php
@@ -1,0 +1,463 @@
+<?php
+
+/**
+ * Content analysis agent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SEO\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+
+/**
+ * Structured content quality score with per-dimension recommendations.
+ *
+ * ## Input
+ *
+ * ```
+ * [
+ *   'content'            => string,      // required
+ *   'primary_keyword'    => string,      // required
+ *   'secondary_keywords' => string[],    // optional
+ * ]
+ * ```
+ *
+ * ## Output schema
+ *
+ * ```
+ * {
+ *   overall_score: int(0..100),
+ *   dimensions: {
+ *     keyword_usage:         { score:int, recommendations:string[] },
+ *     readability:           { score:int, recommendations:string[] },
+ *     structure:             { score:int, recommendations:string[] },
+ *     semantic_completeness: { score:int, recommendations:string[] }
+ *   }
+ * }
+ * ```
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.2.0
+ */
+class ContentAnalysisAgent extends ArtisanPackAgent
+{
+
+	/**
+	 * Dimensions scored on every run.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @var array<int, string>
+	 */
+	protected const DIMENSIONS = [
+		'keyword_usage',
+		'readability',
+		'structure',
+		'semantic_completeness',
+	];
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $featureKey = 'seo.analyze_content';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $package = 'artisanpack-ui/seo';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $defaultModel = 'claude-sonnet-4-5';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public bool $stream = true;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function instructions(): string
+	{
+		return <<<'PROMPT'
+You analyze web page content for SEO quality across four dimensions and return concrete, actionable recommendations.
+
+Dimensions:
+- keyword_usage: density, placement, natural inclusion of primary and secondary keywords.
+- readability: sentence length, paragraph length, transition words, active voice, jargon.
+- structure: heading hierarchy, subheading distribution, list/bullet usage, scannability.
+- semantic_completeness: topical coverage, related entities, questions a reader would still have.
+
+Requirements:
+- Score each dimension from 0 to 100. `overall_score` is a rounded weighted average (keyword_usage 30%, readability 25%, structure 20%, semantic_completeness 25%).
+- Every dimension MUST have between 1 and 5 recommendations. Recommendations MUST be concrete, imperative sentences that reference the actual content (e.g. "shorten the 32-word sentence in paragraph 2", "add an H3 under 'Getting Started'"). Never emit generic advice like "improve readability", "add more content", or "N/A".
+- If the content is short, thin, or otherwise limits your judgment for a dimension, score it low (0-40) and use the recommendations to describe exactly what is missing (e.g. "no H2/H3 headings present — add at least two section headings"). Do NOT skip a dimension or return placeholder text.
+- Do NOT invent facts about the content — quote or reference what is actually there.
+
+Return a JSON object with keys: overall_score (integer 0-100) and dimensions (object with keys keyword_usage, readability, structure, semantic_completeness — each an object with score:int and recommendations:string[]).
+PROMPT;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function outputSchema(): array
+	{
+		$dimensionSchema = [
+			'type'       => 'object',
+			'required'   => [ 'score', 'recommendations' ],
+			'properties' => [
+				'score'           => [ 'type' => 'integer', 'minimum' => 0, 'maximum' => 100 ],
+				'recommendations' => [
+					'type'  => 'array',
+					'items' => [ 'type' => 'string' ],
+				],
+			],
+		];
+
+		return [
+			'type'       => 'object',
+			'required'   => [ 'overall_score', 'dimensions' ],
+			'properties' => [
+				'overall_score' => [ 'type' => 'integer', 'minimum' => 0, 'maximum' => 100 ],
+				'dimensions'    => [
+					'type'       => 'object',
+					'required'   => self::DIMENSIONS,
+					'properties' => [
+						'keyword_usage'         => $dimensionSchema,
+						'readability'           => $dimensionSchema,
+						'structure'             => $dimensionSchema,
+						'semantic_completeness' => $dimensionSchema,
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( Credentials $credentials, string $model, string $instructions ): array
+	{
+		$normalized = $this->normalizeInput( $this->input() );
+
+		$prompter = app( AgentPrompter::class );
+
+		$result = $prompter->prompt(
+			credentials: $credentials,
+			model: $model,
+			instructions: $instructions,
+			message: $this->buildMessage( $normalized ),
+			outputSchema: $this->outputSchema(),
+		);
+
+		return [
+			'output'        => $this->validateOutput( $this->unwrapNestedPayload( $result['output'] ?? [] ) ),
+			'input_tokens'  => (int) ( $result['input_tokens'] ?? 0 ),
+			'output_tokens' => (int) ( $result['output_tokens'] ?? 0 ),
+		];
+	}
+
+	/**
+	 * Validate and shape-check the raw agent input.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  mixed  $input  Raw agent input.
+	 *
+	 * @return array{ content: string, primary_keyword: string, secondary_keywords: array<int, string> }
+	 */
+	protected function normalizeInput( mixed $input ): array
+	{
+		if ( ! is_array( $input ) ) {
+			throw FeatureError::forFeature(
+				$this->featureKey,
+				'input must be an array with `content` and `primary_keyword` keys.',
+			);
+		}
+
+		$content = isset( $input['content'] ) && is_string( $input['content'] ) ? trim( $input['content'] ) : '';
+
+		if ( '' === $content ) {
+			throw FeatureError::forFeature( $this->featureKey, '`content` must be a non-empty string.' );
+		}
+
+		$primary = isset( $input['primary_keyword'] ) && is_string( $input['primary_keyword'] )
+			? trim( $input['primary_keyword'] )
+			: '';
+
+		if ( '' === $primary ) {
+			throw FeatureError::forFeature( $this->featureKey, '`primary_keyword` must be a non-empty string.' );
+		}
+
+		$secondary = [];
+
+		if ( isset( $input['secondary_keywords'] ) && is_array( $input['secondary_keywords'] ) ) {
+			foreach ( $input['secondary_keywords'] as $keyword ) {
+				if ( is_string( $keyword ) && '' !== trim( $keyword ) ) {
+					$secondary[] = trim( $keyword );
+				}
+			}
+		}
+
+		return [
+			'content'            => $content,
+			'primary_keyword'    => $primary,
+			'secondary_keywords' => $secondary,
+		];
+	}
+
+	/**
+	 * Assemble the structured message body for the prompter.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  array{ content: string, primary_keyword: string, secondary_keywords: array<int, string> }  $normalized  Normalized input.
+	 *
+	 * @return array<int, array<string, string>>
+	 */
+	protected function buildMessage( array $normalized ): array
+	{
+		$parts = [
+			[ 'type' => 'text', 'text' => sprintf( 'Primary keyword: %s', $normalized['primary_keyword'] ) ],
+		];
+
+		if ( [] !== $normalized['secondary_keywords'] ) {
+			$parts[] = [
+				'type' => 'text',
+				'text' => 'Secondary keywords: ' . implode( ', ', $normalized['secondary_keywords'] ),
+			];
+		}
+
+		$parts[] = [ 'type' => 'text', 'text' => "Page content:\n" . $normalized['content'] ];
+
+		return $parts;
+	}
+
+	/**
+	 * Unwrap a stringified nested payload the model sometimes returns.
+	 *
+	 * The `laravel/ai` `StructuredAnonymousAgent` mangles the tool spec for
+	 * schemas with a nested `object` field (like our `dimensions`). When it
+	 * does, Anthropic returns the entire intended JSON as a *string* stuffed
+	 * into one of the top-level fields — for us, that's `dimensions`. Rather
+	 * than let the (real, useful) response fall on the floor and score 0/100
+	 * across the board, detect that shape and JSON-decode it back into the
+	 * expected structure. Correctly-shaped payloads pass through unchanged.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  array<string, mixed>  $output  Raw prompter output.
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function unwrapNestedPayload( array $output ): array
+	{
+		// Recurse up to a few levels deep looking for the correctly-shaped
+		// payload. Both known bugs (stringified JSON stuffed into a field,
+		// or the full response wrapped one level too deep inside a field)
+		// resolve the same way: find the first array with our expected
+		// top-level keys and use it.
+		return $this->findPayload( $output, 0 ) ?? $output;
+	}
+
+	/**
+	 * Recursively hunt for an array shaped like the agent's true output.
+	 *
+	 * A correctly-shaped payload has `overall_score` alongside a `dimensions`
+	 * array. When the tool-use bridge misroutes the response, that payload
+	 * may end up one to two levels deeper — as either a nested object or a
+	 * stringified JSON blob — inside a wrong-typed field. This walks a
+	 * bounded depth of the tree and returns the first match.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  mixed  $value  Node to inspect.
+	 * @param  int    $depth  Current recursion depth.
+	 *
+	 * @return array<string, mixed>|null Correctly-shaped payload, or null when nothing matches.
+	 */
+	protected function findPayload( mixed $value, int $depth ): ?array
+	{
+		if ( $depth > 3 ) {
+			return null;
+		}
+
+		if ( is_string( $value ) ) {
+			$decoded = json_decode( $value, true );
+
+			return is_array( $decoded ) ? $this->findPayload( $decoded, $depth + 1 ) : null;
+		}
+
+		if ( ! is_array( $value ) ) {
+			return null;
+		}
+
+		// Third observed shape: `overall_score` is reported honestly at the
+		// top level, but `dimensions` is a JSON-encoded string of just the
+		// dimensions object (no nested `overall_score`). Decode the string
+		// and, if it looks like a real dimensions map, recombine with the
+		// top-level score.
+		if (
+			isset( $value['overall_score'] )
+			&& isset( $value['dimensions'] )
+			&& is_string( $value['dimensions'] )
+		) {
+			$decodedDimensions = json_decode( $value['dimensions'], true );
+
+			if ( $this->looksLikeDimensionsMap( $decodedDimensions ) ) {
+				return [
+					'overall_score' => $value['overall_score'],
+					'dimensions'    => $decodedDimensions,
+				];
+			}
+		}
+
+		if (
+			isset( $value['overall_score'] )
+			&& isset( $value['dimensions'] )
+			&& is_array( $value['dimensions'] )
+			&& ! isset( $value['dimensions']['overall_score'] )
+		) {
+			return $value;
+		}
+
+		foreach ( $value as $child ) {
+			$match = $this->findPayload( $child, $depth + 1 );
+
+			if ( null !== $match ) {
+				return $match;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Determine whether a decoded value resembles a dimensions map (has at
+	 * least one of the four dimension keys with a score/recommendations pair).
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  mixed  $value  Decoded candidate.
+	 *
+	 * @return bool
+	 */
+	protected function looksLikeDimensionsMap( mixed $value ): bool
+	{
+		if ( ! is_array( $value ) ) {
+			return false;
+		}
+
+		foreach ( self::DIMENSIONS as $key ) {
+			if ( isset( $value[ $key ] ) && is_array( $value[ $key ] ) && isset( $value[ $key ]['score'] ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Enforce output invariants — dimension presence, score bounds.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  array<string, mixed>  $output  Decoded model output.
+	 *
+	 * @return array{ overall_score: int, dimensions: array<string, array{ score: int, recommendations: array<int, string> }> }
+	 */
+	protected function validateOutput( array $output ): array
+	{
+		$rawDimensions = is_array( $output['dimensions'] ?? null ) ? $output['dimensions'] : [];
+		$dimensions    = [];
+
+		foreach ( self::DIMENSIONS as $key ) {
+			$entry = is_array( $rawDimensions[ $key ] ?? null ) ? $rawDimensions[ $key ] : [];
+
+			$dimensions[ $key ] = [
+				'score'           => $this->clampScore( $entry['score'] ?? 0 ),
+				'recommendations' => $this->stringList( $entry['recommendations'] ?? [] ),
+			];
+		}
+
+		return [
+			'overall_score' => $this->clampScore( $output['overall_score'] ?? 0 ),
+			'dimensions'    => $dimensions,
+		];
+	}
+
+	/**
+	 * Coerce a value into an integer bounded to [0, 100].
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  mixed  $value  Raw score.
+	 *
+	 * @return int
+	 */
+	protected function clampScore( mixed $value ): int
+	{
+		$score = (int) $value;
+
+		return max( 0, min( 100, $score ) );
+	}
+
+	/**
+	 * Filter a raw list into a clean array of non-empty strings.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  mixed  $raw  Raw list from the model.
+	 *
+	 * @return array<int, string>
+	 */
+	protected function stringList( mixed $raw ): array
+	{
+		if ( ! is_array( $raw ) ) {
+			return [];
+		}
+
+		$out = [];
+
+		foreach ( $raw as $value ) {
+			if ( ! is_string( $value ) ) {
+				continue;
+			}
+
+			$trimmed = trim( $value );
+
+			if ( '' === $trimmed ) {
+				continue;
+			}
+
+			// Reject hedge/placeholder strings the model sometimes emits
+			// when it can't or won't judge a dimension. The prompt already
+			// forbids these, but LLMs occasionally slip them through; the
+			// caller is better served by an empty list than by unactionable
+			// noise.
+			if ( in_array( strtolower( $trimmed ), [ 'n/a', 'na', 'none', 'nothing', 'no recommendations' ], true ) ) {
+				continue;
+			}
+
+			$out[] = $trimmed;
+		}
+
+		return $out;
+	}
+}

--- a/src/Ai/Agents/HreflangSuggestionAgent.php
+++ b/src/Ai/Agents/HreflangSuggestionAgent.php
@@ -1,0 +1,329 @@
+<?php
+
+/**
+ * Hreflang suggestion agent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SEO\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+
+/**
+ * Cross-reference hreflang relationships and surface gaps/inconsistencies.
+ *
+ * ## Input
+ *
+ * ```
+ * [
+ *   'pages' => [
+ *     {
+ *       'url'          => string,
+ *       'lang'         => string,
+ *       'translations' => [ { 'url' => string, 'lang' => string } ]
+ *     }
+ *   ]
+ * ]
+ * ```
+ *
+ * ## Output schema
+ *
+ * ```
+ * {
+ *   issues: [
+ *     {
+ *       page_url:            string,
+ *       issue_type:          enum,
+ *       suggested_hreflang:  [ { lang: string, url: string } ]
+ *     }
+ *   ]
+ * }
+ * ```
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.2.0
+ */
+class HreflangSuggestionAgent extends ArtisanPackAgent
+{
+
+	/**
+	 * Recognised issue categories.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @var array<int, string>
+	 */
+	public const ISSUE_TYPES = [
+		'missing_reciprocal',
+		'missing_translation',
+		'missing_self',
+		'missing_x_default',
+		'inconsistent_lang',
+	];
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $featureKey = 'seo.suggest_hreflang';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $package = 'artisanpack-ui/seo';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $defaultModel = 'claude-haiku-4-5';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function instructions(): string
+	{
+		$types = implode( ', ', self::ISSUE_TYPES );
+
+		return <<<PROMPT
+You cross-reference hreflang relationships across a set of pages and surface where they are missing or inconsistent.
+
+Issue types (use exactly one per issue): {$types}.
+
+Definitions:
+- missing_reciprocal: page A links to page B via hreflang, but B does NOT link back to A.
+- missing_translation: a page has translations for some but not all languages that appear across the page set.
+- missing_self: the page does not include a self-referential hreflang tag pointing to itself.
+- missing_x_default: no `x-default` fallback is declared across the language cluster.
+- inconsistent_lang: a translation url exists but under a different `lang` code than the target page reports.
+
+Requirements:
+- Return one issue per detected problem. Do NOT collapse multiple pages into one issue.
+- `suggested_hreflang` contains the full recommended set for `page_url`, INCLUDING the self-referential entry.
+- Use BCP 47 language tags exactly as they appeared in the input (do not lowercase or normalize).
+- If a page has no issues, do not emit an entry for it.
+- If the input contains no issues at all, return `issues: []`.
+
+Return a JSON object with key `issues` (array of objects with page_url, issue_type, suggested_hreflang).
+PROMPT;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function outputSchema(): array
+	{
+		return [
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'required'             => [ 'issues' ],
+			'properties'           => [
+				'issues' => [
+					'type'  => 'array',
+					'items' => [
+						'type'                 => 'object',
+						'additionalProperties' => false,
+						'required'             => [ 'page_url', 'issue_type', 'suggested_hreflang' ],
+						'properties'           => [
+							'page_url'           => [ 'type' => 'string' ],
+							'issue_type'         => [ 'type' => 'string', 'enum' => self::ISSUE_TYPES ],
+							'suggested_hreflang' => [
+								'type'  => 'array',
+								'items' => [
+									'type'                 => 'object',
+									'additionalProperties' => false,
+									'required'             => [ 'lang', 'url' ],
+									'properties'           => [
+										'lang' => [ 'type' => 'string' ],
+										'url'  => [ 'type' => 'string' ],
+									],
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( Credentials $credentials, string $model, string $instructions ): array
+	{
+		$normalized = $this->normalizeInput( $this->input() );
+
+		if ( [] === $normalized['pages'] ) {
+			return [
+				'output'        => [ 'issues' => [] ],
+				'input_tokens'  => 0,
+				'output_tokens' => 0,
+			];
+		}
+
+		$prompter = app( AgentPrompter::class );
+
+		$result = $prompter->prompt(
+			credentials: $credentials,
+			model: $model,
+			instructions: $instructions,
+			message: $this->buildMessage( $normalized ),
+			outputSchema: $this->outputSchema(),
+		);
+
+		return [
+			'output'        => $this->validateOutput( $result['output'] ?? [] ),
+			'input_tokens'  => (int) ( $result['input_tokens'] ?? 0 ),
+			'output_tokens' => (int) ( $result['output_tokens'] ?? 0 ),
+		];
+	}
+
+	/**
+	 * Validate and shape-check the raw agent input.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  mixed  $input  Raw agent input.
+	 *
+	 * @return array{ pages: array<int, array{ url: string, lang: string, translations: array<int, array{ url: string, lang: string }> }> }
+	 */
+	protected function normalizeInput( mixed $input ): array
+	{
+		if ( ! is_array( $input ) || ! isset( $input['pages'] ) || ! is_array( $input['pages'] ) ) {
+			throw FeatureError::forFeature(
+				$this->featureKey,
+				'input must be an array with a `pages` key.',
+			);
+		}
+
+		$pages = [];
+
+		foreach ( $input['pages'] as $page ) {
+			if ( ! is_array( $page ) ) {
+				continue;
+			}
+
+			$url  = isset( $page['url'] ) && is_string( $page['url'] ) ? trim( $page['url'] ) : '';
+			$lang = isset( $page['lang'] ) && is_string( $page['lang'] ) ? trim( $page['lang'] ) : '';
+
+			if ( '' === $url || '' === $lang ) {
+				continue;
+			}
+
+			$translations = [];
+
+			if ( isset( $page['translations'] ) && is_array( $page['translations'] ) ) {
+				foreach ( $page['translations'] as $translation ) {
+					if ( ! is_array( $translation ) ) {
+						continue;
+					}
+
+					$tUrl  = isset( $translation['url'] ) && is_string( $translation['url'] ) ? trim( $translation['url'] ) : '';
+					$tLang = isset( $translation['lang'] ) && is_string( $translation['lang'] ) ? trim( $translation['lang'] ) : '';
+
+					if ( '' === $tUrl || '' === $tLang ) {
+						continue;
+					}
+
+					$translations[] = [ 'url' => $tUrl, 'lang' => $tLang ];
+				}
+			}
+
+			$pages[] = [
+				'url'          => $url,
+				'lang'         => $lang,
+				'translations' => $translations,
+			];
+		}
+
+		return [ 'pages' => $pages ];
+	}
+
+	/**
+	 * Assemble the structured message body for the prompter.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  array{ pages: array<int, array<string, mixed>> }  $normalized  Normalized input.
+	 *
+	 * @return array<int, array<string, string>>
+	 */
+	protected function buildMessage( array $normalized ): array
+	{
+		return [
+			[
+				'type' => 'text',
+				'text' => "Pages:\n" . json_encode(
+					$normalized['pages'],
+					JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT,
+				),
+			],
+		];
+	}
+
+	/**
+	 * Enforce output invariants — issue-type enum, hreflang shape.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  array<string, mixed>  $output  Decoded model output.
+	 *
+	 * @return array{ issues: array<int, array{ page_url: string, issue_type: string, suggested_hreflang: array<int, array{ lang: string, url: string }> }> }
+	 */
+	protected function validateOutput( array $output ): array
+	{
+		$raw    = is_array( $output['issues'] ?? null ) ? $output['issues'] : [];
+		$issues = [];
+
+		foreach ( $raw as $issue ) {
+			if ( ! is_array( $issue ) ) {
+				continue;
+			}
+
+			$pageUrl   = isset( $issue['page_url'] ) ? trim( (string) $issue['page_url'] ) : '';
+			$issueType = isset( $issue['issue_type'] ) ? (string) $issue['issue_type'] : '';
+
+			if ( '' === $pageUrl || ! in_array( $issueType, self::ISSUE_TYPES, true ) ) {
+				continue;
+			}
+
+			$suggested = [];
+
+			if ( isset( $issue['suggested_hreflang'] ) && is_array( $issue['suggested_hreflang'] ) ) {
+				foreach ( $issue['suggested_hreflang'] as $entry ) {
+					if ( ! is_array( $entry ) ) {
+						continue;
+					}
+
+					$lang = isset( $entry['lang'] ) ? trim( (string) $entry['lang'] ) : '';
+					$url  = isset( $entry['url'] ) ? trim( (string) $entry['url'] ) : '';
+
+					if ( '' === $lang || '' === $url ) {
+						continue;
+					}
+
+					$suggested[] = [ 'lang' => $lang, 'url' => $url ];
+				}
+			}
+
+			$issues[] = [
+				'page_url'           => $pageUrl,
+				'issue_type'         => $issueType,
+				'suggested_hreflang' => $suggested,
+			];
+		}
+
+		return [ 'issues' => $issues ];
+	}
+}

--- a/src/Ai/Agents/MetaDescriptionAgent.php
+++ b/src/Ai/Agents/MetaDescriptionAgent.php
@@ -1,0 +1,206 @@
+<?php
+
+/**
+ * Meta description agent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SEO\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+
+/**
+ * Generate one meta description between 150 and 160 characters.
+ *
+ * ## Input
+ *
+ * ```
+ * [
+ *   'content'         => string,   // required
+ *   'primary_keyword' => string,   // optional
+ * ]
+ * ```
+ *
+ * ## Output schema
+ *
+ * ```
+ * {
+ *   meta_description: string(<=160),
+ *   character_count:  int,
+ *   rationale:        string
+ * }
+ * ```
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.2.0
+ */
+class MetaDescriptionAgent extends ArtisanPackAgent
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $featureKey = 'seo.suggest_meta_description';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $package = 'artisanpack-ui/seo';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $defaultModel = 'claude-haiku-4-5';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function instructions(): string
+	{
+		return <<<'PROMPT'
+You generate a single SEO meta description for a web page.
+
+Requirements:
+- The `meta_description` MUST be between 150 and 160 characters inclusive, including spaces and punctuation. Set `character_count` to the exact length.
+- Naturally include `primary_keyword` (or a very close morphological variant) when provided — do NOT keyword-stuff.
+- Summarize the value the page delivers to the reader. Use active voice.
+- End with an implicit call to action ("Learn how...", "Discover...", "See...") when it fits naturally.
+- `rationale` is one sentence explaining the angle you took.
+
+Return a JSON object with keys: meta_description (string), character_count (int), rationale (string).
+PROMPT;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function outputSchema(): array
+	{
+		return [
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'required'             => [ 'meta_description', 'character_count', 'rationale' ],
+			'properties'           => [
+				'meta_description' => [ 'type' => 'string', 'maxLength' => 160 ],
+				'character_count'  => [ 'type' => 'integer', 'minimum' => 1, 'maximum' => 160 ],
+				'rationale'        => [ 'type' => 'string' ],
+			],
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( Credentials $credentials, string $model, string $instructions ): array
+	{
+		$normalized = $this->normalizeInput( $this->input() );
+
+		$prompter = app( AgentPrompter::class );
+
+		$result = $prompter->prompt(
+			credentials: $credentials,
+			model: $model,
+			instructions: $instructions,
+			message: $this->buildMessage( $normalized ),
+			outputSchema: $this->outputSchema(),
+		);
+
+		return [
+			'output'        => $this->validateOutput( $result['output'] ?? [] ),
+			'input_tokens'  => (int) ( $result['input_tokens'] ?? 0 ),
+			'output_tokens' => (int) ( $result['output_tokens'] ?? 0 ),
+		];
+	}
+
+	/**
+	 * Validate and shape-check the raw agent input.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  mixed  $input  Raw agent input.
+	 *
+	 * @return array{ content: string, primary_keyword: string|null }
+	 */
+	protected function normalizeInput( mixed $input ): array
+	{
+		if ( ! is_array( $input ) ) {
+			throw FeatureError::forFeature(
+				$this->featureKey,
+				'input must be an array with a `content` key.',
+			);
+		}
+
+		$content = isset( $input['content'] ) && is_string( $input['content'] ) ? trim( $input['content'] ) : '';
+
+		if ( '' === $content ) {
+			throw FeatureError::forFeature( $this->featureKey, '`content` must be a non-empty string.' );
+		}
+
+		$primary = isset( $input['primary_keyword'] ) && is_string( $input['primary_keyword'] )
+			? trim( $input['primary_keyword'] )
+			: '';
+
+		return [
+			'content'         => $content,
+			'primary_keyword' => '' === $primary ? null : $primary,
+		];
+	}
+
+	/**
+	 * Assemble the structured message body for the prompter.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  array{ content: string, primary_keyword: string|null }  $normalized  Normalized input.
+	 *
+	 * @return array<int, array<string, string>>
+	 */
+	protected function buildMessage( array $normalized ): array
+	{
+		$parts = [];
+
+		if ( null !== $normalized['primary_keyword'] ) {
+			$parts[] = [ 'type' => 'text', 'text' => sprintf( 'Primary keyword: %s', $normalized['primary_keyword'] ) ];
+		}
+
+		$parts[] = [ 'type' => 'text', 'text' => "Page content:\n" . $normalized['content'] ];
+
+		return $parts;
+	}
+
+	/**
+	 * Enforce output invariants — clamp length, coerce counts.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  array<string, mixed>  $output  Decoded model output.
+	 *
+	 * @return array{ meta_description: string, character_count: int, rationale: string }
+	 */
+	protected function validateOutput( array $output ): array
+	{
+		$description = isset( $output['meta_description'] ) ? trim( (string) $output['meta_description'] ) : '';
+
+		if ( mb_strlen( $description ) > 160 ) {
+			$description = mb_substr( $description, 0, 160 );
+		}
+
+		return [
+			'meta_description' => $description,
+			'character_count'  => mb_strlen( $description ),
+			'rationale'        => isset( $output['rationale'] ) ? trim( (string) $output['rationale'] ) : '',
+		];
+	}
+}

--- a/src/Ai/Agents/MetaTitleSuggestionAgent.php
+++ b/src/Ai/Agents/MetaTitleSuggestionAgent.php
@@ -1,0 +1,250 @@
+<?php
+
+/**
+ * Meta title suggestion agent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SEO\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+
+/**
+ * Suggest 3-5 SEO title variants for a page.
+ *
+ * ## Input
+ *
+ * ```
+ * [
+ *   'content'         => string,   // required
+ *   'primary_keyword' => string,   // optional
+ *   'brand'           => string,   // optional
+ * ]
+ * ```
+ *
+ * ## Output schema
+ *
+ * ```
+ * {
+ *   variants: [
+ *     { title: string(<=60), char_count: int, rationale: string }
+ *   ]
+ * }
+ * ```
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.2.0
+ */
+class MetaTitleSuggestionAgent extends ArtisanPackAgent
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $featureKey = 'seo.suggest_meta_title';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $package = 'artisanpack-ui/seo';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $defaultModel = 'claude-haiku-4-5';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function instructions(): string
+	{
+		return <<<'PROMPT'
+You generate 3 to 5 SEO title variants for a single web page.
+
+Requirements:
+- Every `title` MUST be 60 characters or fewer, including spaces and punctuation. Set `char_count` to the exact length.
+- Optimize for click-through: front-load the strongest term, prefer specific over generic, avoid clickbait, avoid ALL-CAPS.
+- When `primary_keyword` is provided, include it verbatim (or a very close morphological variant) in every variant, ideally near the start.
+- When `brand` is provided, append it separated by " | " ONLY when it fits under the 60-character limit; otherwise omit it.
+- Each `rationale` is a single sentence (<= 140 chars) explaining what angle the variant leans on.
+- Return between 3 and 5 variants. Do not return duplicates or trivial re-orderings.
+
+Return a JSON object with key `variants` (array of objects with `title`, `char_count`, `rationale`).
+PROMPT;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function outputSchema(): array
+	{
+		return [
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'required'             => [ 'variants' ],
+			'properties'           => [
+				'variants' => [
+					'type'     => 'array',
+					'minItems' => 3,
+					'maxItems' => 5,
+					'items'    => [
+						'type'                 => 'object',
+						'additionalProperties' => false,
+						'required'             => [ 'title', 'char_count', 'rationale' ],
+						'properties'           => [
+							'title'      => [ 'type' => 'string', 'maxLength' => 60 ],
+							'char_count' => [ 'type' => 'integer', 'minimum' => 1, 'maximum' => 60 ],
+							'rationale'  => [ 'type' => 'string' ],
+						],
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( Credentials $credentials, string $model, string $instructions ): array
+	{
+		$normalized = $this->normalizeInput( $this->input() );
+
+		$prompter = app( AgentPrompter::class );
+
+		$result = $prompter->prompt(
+			credentials: $credentials,
+			model: $model,
+			instructions: $instructions,
+			message: $this->buildMessage( $normalized ),
+			outputSchema: $this->outputSchema(),
+		);
+
+		return [
+			'output'        => $this->validateOutput( $result['output'] ?? [] ),
+			'input_tokens'  => (int) ( $result['input_tokens'] ?? 0 ),
+			'output_tokens' => (int) ( $result['output_tokens'] ?? 0 ),
+		];
+	}
+
+	/**
+	 * Validate and shape-check the raw agent input.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  mixed  $input  Raw agent input.
+	 *
+	 * @return array{ content: string, primary_keyword: string|null, brand: string|null }
+	 */
+	protected function normalizeInput( mixed $input ): array
+	{
+		if ( ! is_array( $input ) ) {
+			throw FeatureError::forFeature(
+				$this->featureKey,
+				'input must be an array with a `content` key.',
+			);
+		}
+
+		$content = isset( $input['content'] ) && is_string( $input['content'] ) ? trim( $input['content'] ) : '';
+
+		if ( '' === $content ) {
+			throw FeatureError::forFeature( $this->featureKey, '`content` must be a non-empty string.' );
+		}
+
+		$primary = isset( $input['primary_keyword'] ) && is_string( $input['primary_keyword'] )
+			? trim( $input['primary_keyword'] )
+			: '';
+		$brand   = isset( $input['brand'] ) && is_string( $input['brand'] ) ? trim( $input['brand'] ) : '';
+
+		return [
+			'content'         => $content,
+			'primary_keyword' => '' === $primary ? null : $primary,
+			'brand'           => '' === $brand ? null : $brand,
+		];
+	}
+
+	/**
+	 * Assemble the structured message body for the prompter.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  array{ content: string, primary_keyword: string|null, brand: string|null }  $normalized  Normalized input.
+	 *
+	 * @return array<int, array<string, string>>
+	 */
+	protected function buildMessage( array $normalized ): array
+	{
+		$parts = [];
+
+		if ( null !== $normalized['primary_keyword'] ) {
+			$parts[] = [ 'type' => 'text', 'text' => sprintf( 'Primary keyword: %s', $normalized['primary_keyword'] ) ];
+		}
+
+		if ( null !== $normalized['brand'] ) {
+			$parts[] = [ 'type' => 'text', 'text' => sprintf( 'Brand: %s', $normalized['brand'] ) ];
+		}
+
+		$parts[] = [ 'type' => 'text', 'text' => "Page content:\n" . $normalized['content'] ];
+
+		return $parts;
+	}
+
+	/**
+	 * Enforce output invariants — variant count, title length, integer counts.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  array<string, mixed>  $output  Decoded model output.
+	 *
+	 * @return array{ variants: array<int, array{ title: string, char_count: int, rationale: string }> }
+	 */
+	protected function validateOutput( array $output ): array
+	{
+		$raw = $output['variants'] ?? [];
+
+		if ( ! is_array( $raw ) ) {
+			$raw = [];
+		}
+
+		$variants = [];
+
+		foreach ( $raw as $variant ) {
+			if ( ! is_array( $variant ) ) {
+				continue;
+			}
+
+			$title = isset( $variant['title'] ) ? trim( (string) $variant['title'] ) : '';
+
+			if ( '' === $title ) {
+				continue;
+			}
+
+			if ( mb_strlen( $title ) > 60 ) {
+				$title = mb_substr( $title, 0, 60 );
+			}
+
+			$variants[] = [
+				'title'      => $title,
+				'char_count' => mb_strlen( $title ),
+				'rationale'  => isset( $variant['rationale'] ) ? trim( (string) $variant['rationale'] ) : '',
+			];
+		}
+
+		if ( count( $variants ) > 5 ) {
+			$variants = array_slice( $variants, 0, 5 );
+		}
+
+		return [ 'variants' => $variants ];
+	}
+}

--- a/src/Ai/Agents/SchemaGenerationAgent.php
+++ b/src/Ai/Agents/SchemaGenerationAgent.php
@@ -1,0 +1,277 @@
+<?php
+
+/**
+ * Schema generation agent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SEO\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+
+/**
+ * Suggest a JSON-LD schema type and produce a starter structure.
+ *
+ * ## Input
+ *
+ * ```
+ * [
+ *   'content' => string,   // required
+ *   'title'   => string,   // required
+ *   'url'     => string,   // optional
+ * ]
+ * ```
+ *
+ * ## Output schema
+ *
+ * ```
+ * {
+ *   suggested_type:          enum(one of SUPPORTED_TYPES),
+ *   confidence:              float(0..1),
+ *   jsonld:                  object,
+ *   missing_required_fields: string[]
+ * }
+ * ```
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.2.0
+ */
+class SchemaGenerationAgent extends ArtisanPackAgent
+{
+
+	/**
+	 * Supported schema.org types, mirroring the existing schema builder.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @var array<int, string>
+	 */
+	public const SUPPORTED_TYPES = [
+		'Article',
+		'BlogPosting',
+		'NewsArticle',
+		'Product',
+		'Event',
+		'Organization',
+		'Person',
+		'LocalBusiness',
+		'Recipe',
+		'Review',
+		'FAQPage',
+		'HowTo',
+		'VideoObject',
+		'WebPage',
+	];
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $featureKey = 'seo.generate_schema';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $package = 'artisanpack-ui/seo';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $defaultModel = 'claude-haiku-4-5';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function instructions(): string
+	{
+		$types = implode( ', ', self::SUPPORTED_TYPES );
+
+		return <<<PROMPT
+You classify web page content into a JSON-LD schema.org type and produce a starter object.
+
+Allowed schema types (pick exactly one): {$types}.
+
+Requirements:
+- `suggested_type` MUST be one of the allowed types verbatim.
+- `confidence` is a float between 0 and 1 representing how certain the choice is.
+- `jsonld` MUST include `@context: "https://schema.org"` and `@type` matching `suggested_type`. Fill required schema.org properties for the chosen type using the provided content — extract values verbatim; do not invent facts, prices, ratings, dates, or authors.
+- Populate `url` in the object when the caller supplies one, and `name`/`headline` from the title.
+- List every REQUIRED schema.org property for the chosen type that you could NOT populate from the input in `missing_required_fields`. An empty array means the object is publish-ready.
+
+Return a JSON object with keys: suggested_type (string), confidence (float), jsonld (object), missing_required_fields (array of strings).
+PROMPT;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function outputSchema(): array
+	{
+		return [
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'required'             => [ 'suggested_type', 'confidence', 'jsonld', 'missing_required_fields' ],
+			'properties'           => [
+				'suggested_type'          => [ 'type' => 'string', 'enum' => self::SUPPORTED_TYPES ],
+				'confidence'              => [ 'type' => 'number', 'minimum' => 0, 'maximum' => 1 ],
+				'jsonld'                  => [ 'type' => 'object' ],
+				'missing_required_fields' => [
+					'type'  => 'array',
+					'items' => [ 'type' => 'string' ],
+				],
+			],
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( Credentials $credentials, string $model, string $instructions ): array
+	{
+		$normalized = $this->normalizeInput( $this->input() );
+
+		$prompter = app( AgentPrompter::class );
+
+		$result = $prompter->prompt(
+			credentials: $credentials,
+			model: $model,
+			instructions: $instructions,
+			message: $this->buildMessage( $normalized ),
+			outputSchema: $this->outputSchema(),
+		);
+
+		return [
+			'output'        => $this->validateOutput( $result['output'] ?? [] ),
+			'input_tokens'  => (int) ( $result['input_tokens'] ?? 0 ),
+			'output_tokens' => (int) ( $result['output_tokens'] ?? 0 ),
+		];
+	}
+
+	/**
+	 * Validate and shape-check the raw agent input.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  mixed  $input  Raw agent input.
+	 *
+	 * @return array{ content: string, title: string, url: string|null }
+	 */
+	protected function normalizeInput( mixed $input ): array
+	{
+		if ( ! is_array( $input ) ) {
+			throw FeatureError::forFeature(
+				$this->featureKey,
+				'input must be an array with `content` and `title` keys.',
+			);
+		}
+
+		$content = isset( $input['content'] ) && is_string( $input['content'] ) ? trim( $input['content'] ) : '';
+		$title   = isset( $input['title'] ) && is_string( $input['title'] ) ? trim( $input['title'] ) : '';
+
+		if ( '' === $content ) {
+			throw FeatureError::forFeature( $this->featureKey, '`content` must be a non-empty string.' );
+		}
+
+		if ( '' === $title ) {
+			throw FeatureError::forFeature( $this->featureKey, '`title` must be a non-empty string.' );
+		}
+
+		$url = isset( $input['url'] ) && is_string( $input['url'] ) ? trim( $input['url'] ) : '';
+
+		return [
+			'content' => $content,
+			'title'   => $title,
+			'url'     => '' === $url ? null : $url,
+		];
+	}
+
+	/**
+	 * Assemble the structured message body for the prompter.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  array{ content: string, title: string, url: string|null }  $normalized  Normalized input.
+	 *
+	 * @return array<int, array<string, string>>
+	 */
+	protected function buildMessage( array $normalized ): array
+	{
+		$parts = [
+			[ 'type' => 'text', 'text' => sprintf( 'Title: %s', $normalized['title'] ) ],
+		];
+
+		if ( null !== $normalized['url'] ) {
+			$parts[] = [ 'type' => 'text', 'text' => sprintf( 'URL: %s', $normalized['url'] ) ];
+		}
+
+		$parts[] = [ 'type' => 'text', 'text' => "Page content:\n" . $normalized['content'] ];
+
+		return $parts;
+	}
+
+	/**
+	 * Enforce output invariants — type in enum, confidence clamped, jsonld shape.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  array<string, mixed>  $output  Decoded model output.
+	 *
+	 * @return array{ suggested_type: string, confidence: float, jsonld: array<string, mixed>, missing_required_fields: array<int, string> }
+	 */
+	protected function validateOutput( array $output ): array
+	{
+		$type        = isset( $output['suggested_type'] ) ? (string) $output['suggested_type'] : '';
+		$typeCoerced = false;
+
+		if ( ! in_array( $type, self::SUPPORTED_TYPES, true ) ) {
+			$type        = 'WebPage';
+			$typeCoerced = true;
+		}
+
+		$confidence = isset( $output['confidence'] ) ? (float) $output['confidence'] : 0.0;
+		$confidence = max( 0.0, min( 1.0, $confidence ) );
+
+		$jsonld = is_array( $output['jsonld'] ?? null ) ? $output['jsonld'] : [];
+
+		if ( ! isset( $jsonld['@context'] ) ) {
+			$jsonld = [ '@context' => 'https://schema.org' ] + $jsonld;
+		}
+
+		// When we coerced `suggested_type` to `WebPage`, force `jsonld['@type']`
+		// to match — otherwise callers get a payload where the top-level type
+		// disagrees with the JSON-LD type and downstream markup would emit the
+		// invalid type verbatim.
+		if ( $typeCoerced || ! isset( $jsonld['@type'] ) ) {
+			$jsonld['@type'] = $type;
+		}
+
+		$missing = [];
+
+		if ( isset( $output['missing_required_fields'] ) && is_array( $output['missing_required_fields'] ) ) {
+			foreach ( $output['missing_required_fields'] as $field ) {
+				if ( is_string( $field ) && '' !== trim( $field ) ) {
+					$missing[] = trim( $field );
+				}
+			}
+		}
+
+		return [
+			'suggested_type'          => $type,
+			'confidence'              => $confidence,
+			'jsonld'                  => $jsonld,
+			'missing_required_fields' => $missing,
+		];
+	}
+}

--- a/src/Http/Controllers/Api/AiAgentApiController.php
+++ b/src/Http/Controllers/Api/AiAgentApiController.php
@@ -1,0 +1,182 @@
+<?php
+
+/**
+ * AiAgentApiController.
+ *
+ * Single dispatch endpoint for the SEO package's AI agents. React/Vue
+ * frontends POST here with a feature key + input payload; the controller
+ * resolves the registered agent, runs it, and returns the structured output.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SEO\Http\Controllers\Api;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
+use ArtisanPackUI\SEO\Ai\Agents\ContentAnalysisAgent;
+use ArtisanPackUI\SEO\Ai\Agents\HreflangSuggestionAgent;
+use ArtisanPackUI\SEO\Ai\Agents\MetaDescriptionAgent;
+use ArtisanPackUI\SEO\Ai\Agents\MetaTitleSuggestionAgent;
+use ArtisanPackUI\SEO\Ai\Agents\SchemaGenerationAgent;
+use ArtisanPackUI\SEO\Http\Requests\Api\Ai\AnalyzeContentAiRequest;
+use ArtisanPackUI\SEO\Http\Requests\Api\Ai\GenerateSchemaAiRequest;
+use ArtisanPackUI\SEO\Http\Requests\Api\Ai\SuggestHreflangAiRequest;
+use ArtisanPackUI\SEO\Http\Requests\Api\Ai\SuggestMetaDescriptionAiRequest;
+use ArtisanPackUI\SEO\Http\Requests\Api\Ai\SuggestMetaTitleAiRequest;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Routing\Controller;
+use Throwable;
+
+/**
+ * Handles API requests for the SEO package's AI agents.
+ *
+ * The controller intentionally holds a static feature → agent map instead
+ * of reflecting through the registry so a caller cannot execute an arbitrary
+ * agent class by naming it in a request body.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.2.0
+ */
+class AiAgentApiController extends Controller
+{
+	/**
+	 * Feature-key → agent-class map for this package.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @var array<string, class-string>
+	 */
+	protected const AGENTS = [
+		'seo.suggest_meta_title'       => MetaTitleSuggestionAgent::class,
+		'seo.suggest_meta_description' => MetaDescriptionAgent::class,
+		'seo.analyze_content'          => ContentAnalysisAgent::class,
+		'seo.generate_schema'          => SchemaGenerationAgent::class,
+		'seo.suggest_hreflang'         => HreflangSuggestionAgent::class,
+	];
+
+	/**
+	 * Suggest 3-5 title variants.
+	 *
+	 * @since 1.2.0
+	 */
+	public function suggestMetaTitle( SuggestMetaTitleAiRequest $request ): JsonResponse
+	{
+		return $this->dispatchAgent( 'seo.suggest_meta_title', $request->validated() );
+	}
+
+	/**
+	 * Suggest a 150-160 character meta description.
+	 *
+	 * @since 1.2.0
+	 */
+	public function suggestMetaDescription( SuggestMetaDescriptionAiRequest $request ): JsonResponse
+	{
+		return $this->dispatchAgent( 'seo.suggest_meta_description', $request->validated() );
+	}
+
+	/**
+	 * Score content quality across four dimensions.
+	 *
+	 * @since 1.2.0
+	 */
+	public function analyzeContent( AnalyzeContentAiRequest $request ): JsonResponse
+	{
+		return $this->dispatchAgent( 'seo.analyze_content', $request->validated() );
+	}
+
+	/**
+	 * Suggest a JSON-LD schema type and starter structure.
+	 *
+	 * @since 1.2.0
+	 */
+	public function generateSchema( GenerateSchemaAiRequest $request ): JsonResponse
+	{
+		return $this->dispatchAgent( 'seo.generate_schema', $request->validated() );
+	}
+
+	/**
+	 * Surface missing or inconsistent hreflang relationships.
+	 *
+	 * @since 1.2.0
+	 */
+	public function suggestHreflang( SuggestHreflangAiRequest $request ): JsonResponse
+	{
+		return $this->dispatchAgent( 'seo.suggest_hreflang', $request->validated() );
+	}
+
+	/**
+	 * Run the agent associated with `$featureKey` against `$input`.
+	 *
+	 * The registry-toggle short-circuit returns a 409 with the feature key so
+	 * frontends can render a "This feature is disabled" state without needing
+	 * to parse the exception message. Missing credentials return 412; validation
+	 * failures inside the agent return 422; anything else is a 500.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  string                $featureKey  Fully-qualified feature key.
+	 * @param  array<string, mixed>  $input       Raw request payload.
+	 *
+	 * @return JsonResponse
+	 */
+	protected function dispatchAgent( string $featureKey, array $input ): JsonResponse
+	{
+		if ( ! isset( self::AGENTS[ $featureKey ] ) ) {
+			return response()->json( [
+				'message' => __( 'Unknown AI feature.' ),
+			], 404 );
+		}
+
+		$registry = app( FeatureRegistry::class );
+
+		if ( null !== $registry->get( $featureKey ) && ! $registry->isToggleOn( $featureKey ) ) {
+			return response()->json( [
+				'message'     => __( 'This AI feature is disabled.' ),
+				'feature_key' => $featureKey,
+			], 409 );
+		}
+
+		$agentClass = self::AGENTS[ $featureKey ];
+
+		try {
+			$output = $agentClass::for( $input )->run();
+		} catch ( FeatureDisabledException $exception ) {
+			return response()->json( [
+				'message'     => $exception->getMessage(),
+				'feature_key' => $featureKey,
+			], 409 );
+		} catch ( MissingCredentialsException $exception ) {
+			return response()->json( [
+				'message'     => $exception->getMessage(),
+				'feature_key' => $featureKey,
+			], 412 );
+		} catch ( FeatureError $exception ) {
+			return response()->json( [
+				'message'     => $exception->getMessage(),
+				'feature_key' => $featureKey,
+			], 422 );
+		} catch ( Throwable $exception ) {
+			return response()->json( [
+				'message'     => __( 'AI agent failed to run.' ),
+				'feature_key' => $featureKey,
+			], 500 );
+		}
+
+		return response()->json( [
+			'data'        => $output,
+			'feature_key' => $featureKey,
+		] );
+	}
+}

--- a/src/Http/Requests/Api/Ai/AnalyzeContentAiRequest.php
+++ b/src/Http/Requests/Api/Ai/AnalyzeContentAiRequest.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * AnalyzeContentAiRequest.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SEO\Http\Requests\Api\Ai;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+/**
+ * Validates requests to the content-analysis AI endpoint.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.2.0
+ */
+class AnalyzeContentAiRequest extends FormRequest
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public function authorize(): bool
+	{
+		return Gate::allows( 'seo.ai.use' );
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function rules(): array
+	{
+		return [
+			'content'              => [ 'required', 'string', 'min:1', 'max:20000' ],
+			'primary_keyword'      => [ 'required', 'string', 'max:200' ],
+			'secondary_keywords'   => [ 'nullable', 'array', 'max:20' ],
+			'secondary_keywords.*' => [ 'string', 'max:200' ],
+		];
+	}
+}

--- a/src/Http/Requests/Api/Ai/GenerateSchemaAiRequest.php
+++ b/src/Http/Requests/Api/Ai/GenerateSchemaAiRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * GenerateSchemaAiRequest.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SEO\Http\Requests\Api\Ai;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+/**
+ * Validates requests to the schema-generation AI endpoint.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.2.0
+ */
+class GenerateSchemaAiRequest extends FormRequest
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public function authorize(): bool
+	{
+		return Gate::allows( 'seo.ai.use' );
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function rules(): array
+	{
+		return [
+			'content' => [ 'required', 'string', 'min:1', 'max:20000' ],
+			'title'   => [ 'required', 'string', 'max:500' ],
+			'url'     => [ 'nullable', 'string', 'max:2048', 'url' ],
+		];
+	}
+}

--- a/src/Http/Requests/Api/Ai/SuggestHreflangAiRequest.php
+++ b/src/Http/Requests/Api/Ai/SuggestHreflangAiRequest.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * SuggestHreflangAiRequest.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SEO\Http\Requests\Api\Ai;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+/**
+ * Validates requests to the hreflang-suggestion AI endpoint.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.2.0
+ */
+class SuggestHreflangAiRequest extends FormRequest
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public function authorize(): bool
+	{
+		return Gate::allows( 'seo.ai.use' );
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function rules(): array
+	{
+		return [
+			'pages'                       => [ 'required', 'array', 'min:1', 'max:500' ],
+			'pages.*.url'                 => [ 'required', 'string', 'max:2048' ],
+			'pages.*.lang'                => [ 'required', 'string', 'max:35' ],
+			'pages.*.translations'        => [ 'nullable', 'array' ],
+			'pages.*.translations.*.url'  => [ 'required', 'string', 'max:2048' ],
+			'pages.*.translations.*.lang' => [ 'required', 'string', 'max:35' ],
+		];
+	}
+}

--- a/src/Http/Requests/Api/Ai/SuggestMetaDescriptionAiRequest.php
+++ b/src/Http/Requests/Api/Ai/SuggestMetaDescriptionAiRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * SuggestMetaDescriptionAiRequest.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SEO\Http\Requests\Api\Ai;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+/**
+ * Validates requests to the meta-description suggestion AI endpoint.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.2.0
+ */
+class SuggestMetaDescriptionAiRequest extends FormRequest
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public function authorize(): bool
+	{
+		return Gate::allows( 'seo.ai.use' );
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function rules(): array
+	{
+		return [
+			'content'         => [ 'required', 'string', 'min:1', 'max:20000' ],
+			'primary_keyword' => [ 'nullable', 'string', 'max:200' ],
+		];
+	}
+}

--- a/src/Http/Requests/Api/Ai/SuggestMetaTitleAiRequest.php
+++ b/src/Http/Requests/Api/Ai/SuggestMetaTitleAiRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * SuggestMetaTitleAiRequest.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SEO\Http\Requests\Api\Ai;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+/**
+ * Validates requests to the meta-title suggestion AI endpoint.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.2.0
+ */
+class SuggestMetaTitleAiRequest extends FormRequest
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public function authorize(): bool
+	{
+		return Gate::allows( 'seo.ai.use' );
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function rules(): array
+	{
+		return [
+			'content'         => [ 'required', 'string', 'min:1', 'max:20000' ],
+			'primary_keyword' => [ 'nullable', 'string', 'max:200' ],
+			'brand'           => [ 'nullable', 'string', 'max:200' ],
+		];
+	}
+}

--- a/src/Livewire/Ai/ContentAnalyzer.php
+++ b/src/Livewire/Ai/ContentAnalyzer.php
@@ -1,0 +1,168 @@
+<?php
+
+/**
+ * ContentAnalyzer Livewire component.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SEO\Livewire\Ai;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
+use ArtisanPackUI\SEO\Ai\Agents\ContentAnalysisAgent;
+use Illuminate\View\View;
+use Livewire\Attributes\On;
+use Livewire\Component;
+use Throwable;
+
+/**
+ * Trigger UI for the {@see ContentAnalysisAgent}.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.2.0
+ */
+class ContentAnalyzer extends Component
+{
+	public string $content = '';
+
+	public string $primaryKeyword = '';
+
+	/**
+	 * @var array<int, string>
+	 */
+	public array $secondaryKeywords = [];
+
+	public bool $isLoading = false;
+
+	public ?string $error = null;
+
+	public ?int $overallScore = null;
+
+	/**
+	 * @var array<string, array{ score: int, recommendations: array<int, string> }>
+	 */
+	public array $dimensions = [];
+
+	/**
+	 * Mount the component with initial context from the containing editor.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  string             $content            Page content.
+	 * @param  string             $primaryKeyword     Focus keyword.
+	 * @param  array<int, string> $secondaryKeywords  Secondary keywords.
+	 */
+	public function mount( string $content = '', string $primaryKeyword = '', array $secondaryKeywords = [] ): void
+	{
+		$this->content           = $content;
+		$this->primaryKeyword    = $primaryKeyword;
+		$this->secondaryKeywords = $secondaryKeywords;
+	}
+
+	/**
+	 * React to the parent editor updating its content payload.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  array{ content?: string, primary_keyword?: string, secondary_keywords?: array<int, string> }  $payload  New context.
+	 *
+	 * @return void
+	 */
+	#[On( 'seo-ai-context-updated' )]
+	public function contextUpdated( array $payload ): void
+	{
+		if ( isset( $payload['content'] ) ) {
+			$this->content = (string) $payload['content'];
+		}
+
+		if ( isset( $payload['primary_keyword'] ) ) {
+			$this->primaryKeyword = (string) $payload['primary_keyword'];
+		}
+
+		if ( isset( $payload['secondary_keywords'] ) && is_array( $payload['secondary_keywords'] ) ) {
+			$this->secondaryKeywords = array_values( array_filter(
+				$payload['secondary_keywords'],
+				static fn ( $value ): bool => is_string( $value ) && '' !== trim( $value ),
+			) );
+		}
+	}
+
+	/**
+	 * Run the agent and populate scores or error.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return void
+	 */
+	public function analyze(): void
+	{
+		$this->error        = null;
+		$this->overallScore = null;
+		$this->dimensions   = [];
+		$this->isLoading    = true;
+
+		try {
+			$output = ContentAnalysisAgent::for( [
+				'content'            => $this->content,
+				'primary_keyword'    => $this->primaryKeyword,
+				'secondary_keywords' => $this->secondaryKeywords,
+			] )->run();
+
+			$this->overallScore = (int) ( $output['overall_score'] ?? 0 );
+			$this->dimensions   = is_array( $output['dimensions'] ?? null ) ? $output['dimensions'] : [];
+		} catch ( FeatureDisabledException $exception ) {
+			$this->error = __( 'This AI feature is disabled.' );
+		} catch ( MissingCredentialsException $exception ) {
+			$this->error = __( 'AI credentials are not configured.' );
+		} catch ( FeatureError $exception ) {
+			$this->error = $exception->getMessage();
+		} catch ( Throwable $exception ) {
+			$this->error = __( 'The AI agent could not complete this request.' );
+		} finally {
+			$this->isLoading = false;
+		}
+	}
+
+	/**
+	 * Determine whether this feature is enabled in the registry.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return bool
+	 */
+	public function getIsEnabledProperty(): bool
+	{
+		$registry = app( FeatureRegistry::class );
+		$key      = 'seo.analyze_content';
+
+		if ( null === $registry->get( $key ) ) {
+			return false;
+		}
+
+		return $registry->isToggleOn( $key );
+	}
+
+	/**
+	 * Render the component view.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return View
+	 */
+	public function render(): View
+	{
+		return view( 'seo::livewire.ai.content-analyzer' );
+	}
+}

--- a/src/Livewire/Ai/HreflangSuggestor.php
+++ b/src/Livewire/Ai/HreflangSuggestor.php
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * HreflangSuggestor Livewire component.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SEO\Livewire\Ai;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
+use ArtisanPackUI\SEO\Ai\Agents\HreflangSuggestionAgent;
+use Illuminate\View\View;
+use Livewire\Attributes\On;
+use Livewire\Component;
+use Throwable;
+
+/**
+ * Trigger UI for the {@see HreflangSuggestionAgent}.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.2.0
+ */
+class HreflangSuggestor extends Component
+{
+	/**
+	 * @var array<int, array{ url: string, lang: string, translations: array<int, array{ url: string, lang: string }> }>
+	 */
+	public array $pages = [];
+
+	public bool $isLoading = false;
+
+	public ?string $error = null;
+
+	/**
+	 * @var array<int, array{ page_url: string, issue_type: string, suggested_hreflang: array<int, array{ lang: string, url: string }> }>
+	 */
+	public array $issues = [];
+
+	/**
+	 * Mount the component with initial pages payload.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  array<int, array<string, mixed>>  $pages  Pages payload.
+	 */
+	public function mount( array $pages = [] ): void
+	{
+		$this->pages = $pages;
+	}
+
+	/**
+	 * React to the parent editor updating the pages payload.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  array{ pages?: array<int, array<string, mixed>> }  $payload  New context.
+	 *
+	 * @return void
+	 */
+	#[On( 'seo-ai-context-updated' )]
+	public function contextUpdated( array $payload ): void
+	{
+		if ( isset( $payload['pages'] ) && is_array( $payload['pages'] ) ) {
+			$this->pages = $payload['pages'];
+		}
+	}
+
+	/**
+	 * Run the agent and populate `$issues` or `$error`.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return void
+	 */
+	public function suggest(): void
+	{
+		$this->error     = null;
+		$this->issues    = [];
+		$this->isLoading = true;
+
+		try {
+			$output = HreflangSuggestionAgent::for( [ 'pages' => $this->pages ] )->run();
+
+			$this->issues = is_array( $output['issues'] ?? null ) ? $output['issues'] : [];
+		} catch ( FeatureDisabledException $exception ) {
+			$this->error = __( 'This AI feature is disabled.' );
+		} catch ( MissingCredentialsException $exception ) {
+			$this->error = __( 'AI credentials are not configured.' );
+		} catch ( FeatureError $exception ) {
+			$this->error = $exception->getMessage();
+		} catch ( Throwable $exception ) {
+			$this->error = __( 'The AI agent could not complete this request.' );
+		} finally {
+			$this->isLoading = false;
+		}
+	}
+
+	/**
+	 * Emit a single fix back to the parent editor.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  int  $index  Issue index.
+	 *
+	 * @return void
+	 */
+	public function applyFix( int $index ): void
+	{
+		if ( ! isset( $this->issues[ $index ] ) ) {
+			return;
+		}
+
+		$this->dispatch(
+			'seo-ai-hreflang-fix-selected',
+			page_url: $this->issues[ $index ]['page_url'],
+			suggested_hreflang: $this->issues[ $index ]['suggested_hreflang'],
+		);
+	}
+
+	/**
+	 * Determine whether this feature is enabled in the registry.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return bool
+	 */
+	public function getIsEnabledProperty(): bool
+	{
+		$registry = app( FeatureRegistry::class );
+		$key      = 'seo.suggest_hreflang';
+
+		if ( null === $registry->get( $key ) ) {
+			return false;
+		}
+
+		return $registry->isToggleOn( $key );
+	}
+
+	/**
+	 * Render the component view.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return View
+	 */
+	public function render(): View
+	{
+		return view( 'seo::livewire.ai.hreflang-suggestor' );
+	}
+}

--- a/src/Livewire/Ai/MetaDescriptionSuggestor.php
+++ b/src/Livewire/Ai/MetaDescriptionSuggestor.php
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * MetaDescriptionSuggestor Livewire component.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SEO\Livewire\Ai;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
+use ArtisanPackUI\SEO\Ai\Agents\MetaDescriptionAgent;
+use Illuminate\View\View;
+use Livewire\Attributes\On;
+use Livewire\Component;
+use Throwable;
+
+/**
+ * Trigger UI for the {@see MetaDescriptionAgent}.
+ *
+ * Emits `seo-ai-description-selected` (payload: `[ 'description' => string ]`)
+ * when the user accepts the suggestion.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.2.0
+ */
+class MetaDescriptionSuggestor extends Component
+{
+	public string $content = '';
+
+	public string $primaryKeyword = '';
+
+	public bool $isLoading = false;
+
+	public ?string $error = null;
+
+	public ?string $suggestion = null;
+
+	public int $characterCount = 0;
+
+	public string $rationale = '';
+
+	/**
+	 * Mount the component with initial context from the containing editor.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  string  $content         Page content.
+	 * @param  string  $primaryKeyword  Focus keyword (optional).
+	 */
+	public function mount( string $content = '', string $primaryKeyword = '' ): void
+	{
+		$this->content        = $content;
+		$this->primaryKeyword = $primaryKeyword;
+	}
+
+	/**
+	 * React to the parent editor updating its content payload.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  array{ content?: string, primary_keyword?: string }  $payload  New context.
+	 *
+	 * @return void
+	 */
+	#[On( 'seo-ai-context-updated' )]
+	public function contextUpdated( array $payload ): void
+	{
+		if ( isset( $payload['content'] ) ) {
+			$this->content = (string) $payload['content'];
+		}
+
+		if ( isset( $payload['primary_keyword'] ) ) {
+			$this->primaryKeyword = (string) $payload['primary_keyword'];
+		}
+	}
+
+	/**
+	 * Run the agent and populate the suggestion or error.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return void
+	 */
+	public function suggest(): void
+	{
+		$this->error          = null;
+		$this->suggestion     = null;
+		$this->characterCount = 0;
+		$this->rationale      = '';
+		$this->isLoading      = true;
+
+		try {
+			$output = MetaDescriptionAgent::for( [
+				'content'         => $this->content,
+				'primary_keyword' => $this->primaryKeyword,
+			] )->run();
+
+			$this->suggestion     = $output['meta_description'] ?? '';
+			$this->characterCount = (int) ( $output['character_count'] ?? 0 );
+			$this->rationale      = (string) ( $output['rationale'] ?? '' );
+		} catch ( FeatureDisabledException $exception ) {
+			$this->error = __( 'This AI feature is disabled.' );
+		} catch ( MissingCredentialsException $exception ) {
+			$this->error = __( 'AI credentials are not configured.' );
+		} catch ( FeatureError $exception ) {
+			$this->error = $exception->getMessage();
+		} catch ( Throwable $exception ) {
+			$this->error = __( 'The AI agent could not complete this request.' );
+		} finally {
+			$this->isLoading = false;
+		}
+	}
+
+	/**
+	 * Emit the current suggestion back to the parent editor.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return void
+	 */
+	public function accept(): void
+	{
+		if ( null === $this->suggestion || '' === $this->suggestion ) {
+			return;
+		}
+
+		$this->dispatch( 'seo-ai-description-selected', description: $this->suggestion );
+	}
+
+	/**
+	 * Determine whether this feature is enabled in the registry.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return bool
+	 */
+	public function getIsEnabledProperty(): bool
+	{
+		$registry = app( FeatureRegistry::class );
+		$key      = 'seo.suggest_meta_description';
+
+		if ( null === $registry->get( $key ) ) {
+			return false;
+		}
+
+		return $registry->isToggleOn( $key );
+	}
+
+	/**
+	 * Render the component view.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return View
+	 */
+	public function render(): View
+	{
+		return view( 'seo::livewire.ai.meta-description-suggestor' );
+	}
+}

--- a/src/Livewire/Ai/MetaTitleSuggestor.php
+++ b/src/Livewire/Ai/MetaTitleSuggestor.php
@@ -1,0 +1,180 @@
+<?php
+
+/**
+ * MetaTitleSuggestor Livewire component.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SEO\Livewire\Ai;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
+use ArtisanPackUI\SEO\Ai\Agents\MetaTitleSuggestionAgent;
+use Illuminate\View\View;
+use Livewire\Attributes\On;
+use Livewire\Component;
+use Throwable;
+
+/**
+ * Trigger UI for the {@see MetaTitleSuggestionAgent}.
+ *
+ * Emits `seo-ai-title-selected` (payload: `[ 'title' => string ]`) when the
+ * user picks a variant, so the containing editor can wire whichever field
+ * update it wants.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.2.0
+ */
+class MetaTitleSuggestor extends Component
+{
+	public string $content = '';
+
+	public string $primaryKeyword = '';
+
+	public string $brand = '';
+
+	public bool $isLoading = false;
+
+	public ?string $error = null;
+
+	/**
+	 * @var array<int, array{ title: string, char_count: int, rationale: string }>
+	 */
+	public array $variants = [];
+
+	/**
+	 * Mount the component with initial context from the containing editor.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  string  $content         Page content.
+	 * @param  string  $primaryKeyword  Focus keyword (optional).
+	 * @param  string  $brand           Brand name (optional).
+	 */
+	public function mount( string $content = '', string $primaryKeyword = '', string $brand = '' ): void
+	{
+		$this->content        = $content;
+		$this->primaryKeyword = $primaryKeyword;
+		$this->brand          = $brand;
+	}
+
+	/**
+	 * React to the parent editor updating its content payload.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  array{ content?: string, primary_keyword?: string, brand?: string }  $payload  New context.
+	 *
+	 * @return void
+	 */
+	#[On( 'seo-ai-context-updated' )]
+	public function contextUpdated( array $payload ): void
+	{
+		if ( isset( $payload['content'] ) ) {
+			$this->content = (string) $payload['content'];
+		}
+
+		if ( isset( $payload['primary_keyword'] ) ) {
+			$this->primaryKeyword = (string) $payload['primary_keyword'];
+		}
+
+		if ( isset( $payload['brand'] ) ) {
+			$this->brand = (string) $payload['brand'];
+		}
+	}
+
+	/**
+	 * Run the agent and populate `$variants` or `$error`.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return void
+	 */
+	public function suggest(): void
+	{
+		$this->error     = null;
+		$this->variants  = [];
+		$this->isLoading = true;
+
+		try {
+			$output = MetaTitleSuggestionAgent::for( [
+				'content'         => $this->content,
+				'primary_keyword' => $this->primaryKeyword,
+				'brand'           => $this->brand,
+			] )->run();
+
+			$this->variants = $output['variants'] ?? [];
+		} catch ( FeatureDisabledException $exception ) {
+			$this->error = __( 'This AI feature is disabled.' );
+		} catch ( MissingCredentialsException $exception ) {
+			$this->error = __( 'AI credentials are not configured.' );
+		} catch ( FeatureError $exception ) {
+			$this->error = $exception->getMessage();
+		} catch ( Throwable $exception ) {
+			$this->error = __( 'The AI agent could not complete this request.' );
+		} finally {
+			$this->isLoading = false;
+		}
+	}
+
+	/**
+	 * Emit the chosen variant back to the parent editor.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  int  $index  Variant index.
+	 *
+	 * @return void
+	 */
+	public function select( int $index ): void
+	{
+		if ( ! isset( $this->variants[ $index ] ) ) {
+			return;
+		}
+
+		$this->dispatch( 'seo-ai-title-selected', title: $this->variants[ $index ]['title'] );
+	}
+
+	/**
+	 * Determine whether this feature is enabled in the registry.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return bool
+	 */
+	public function getIsEnabledProperty(): bool
+	{
+		$registry = app( FeatureRegistry::class );
+		$key      = 'seo.suggest_meta_title';
+
+		if ( null === $registry->get( $key ) ) {
+			return false;
+		}
+
+		return $registry->isToggleOn( $key );
+	}
+
+	/**
+	 * Render the component view.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return View
+	 */
+	public function render(): View
+	{
+		return view( 'seo::livewire.ai.meta-title-suggestor' );
+	}
+}

--- a/src/Livewire/Ai/SchemaSuggestor.php
+++ b/src/Livewire/Ai/SchemaSuggestor.php
@@ -1,0 +1,197 @@
+<?php
+
+/**
+ * SchemaSuggestor Livewire component.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SEO\Livewire\Ai;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
+use ArtisanPackUI\SEO\Ai\Agents\SchemaGenerationAgent;
+use Illuminate\View\View;
+use Livewire\Attributes\On;
+use Livewire\Component;
+use Throwable;
+
+/**
+ * Trigger UI for the {@see SchemaGenerationAgent}.
+ *
+ * Emits `seo-ai-schema-selected` (payload: `[ 'type' => string, 'jsonld' => array ]`)
+ * when the user accepts the suggestion.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.2.0
+ */
+class SchemaSuggestor extends Component
+{
+	public string $content = '';
+
+	public string $title = '';
+
+	public string $url = '';
+
+	public bool $isLoading = false;
+
+	public ?string $error = null;
+
+	public ?string $suggestedType = null;
+
+	public float $confidence = 0.0;
+
+	/**
+	 * @var array<string, mixed>
+	 */
+	public array $jsonld = [];
+
+	/**
+	 * @var array<int, string>
+	 */
+	public array $missingRequiredFields = [];
+
+	/**
+	 * Mount the component with initial context from the containing editor.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  string  $content  Page content.
+	 * @param  string  $title    Page title.
+	 * @param  string  $url      Page URL (optional).
+	 */
+	public function mount( string $content = '', string $title = '', string $url = '' ): void
+	{
+		$this->content = $content;
+		$this->title   = $title;
+		$this->url     = $url;
+	}
+
+	/**
+	 * React to the parent editor updating its content payload.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  array{ content?: string, title?: string, url?: string }  $payload  New context.
+	 *
+	 * @return void
+	 */
+	#[On( 'seo-ai-context-updated' )]
+	public function contextUpdated( array $payload ): void
+	{
+		if ( isset( $payload['content'] ) ) {
+			$this->content = (string) $payload['content'];
+		}
+
+		if ( isset( $payload['title'] ) ) {
+			$this->title = (string) $payload['title'];
+		}
+
+		if ( isset( $payload['url'] ) ) {
+			$this->url = (string) $payload['url'];
+		}
+	}
+
+	/**
+	 * Run the agent and populate suggestion or error.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return void
+	 */
+	public function suggest(): void
+	{
+		$this->error                 = null;
+		$this->suggestedType         = null;
+		$this->confidence            = 0.0;
+		$this->jsonld                = [];
+		$this->missingRequiredFields = [];
+		$this->isLoading             = true;
+
+		try {
+			$output = SchemaGenerationAgent::for( [
+				'content' => $this->content,
+				'title'   => $this->title,
+				'url'     => $this->url,
+			] )->run();
+
+			$this->suggestedType         = (string) ( $output['suggested_type'] ?? '' );
+			$this->confidence            = (float) ( $output['confidence'] ?? 0 );
+			$this->jsonld                = is_array( $output['jsonld'] ?? null ) ? $output['jsonld'] : [];
+			$this->missingRequiredFields = is_array( $output['missing_required_fields'] ?? null )
+				? array_values( array_filter(
+					$output['missing_required_fields'],
+					static fn ( $value ): bool => is_string( $value ) && '' !== trim( $value ),
+				) )
+				: [];
+		} catch ( FeatureDisabledException $exception ) {
+			$this->error = __( 'This AI feature is disabled.' );
+		} catch ( MissingCredentialsException $exception ) {
+			$this->error = __( 'AI credentials are not configured.' );
+		} catch ( FeatureError $exception ) {
+			$this->error = $exception->getMessage();
+		} catch ( Throwable $exception ) {
+			$this->error = __( 'The AI agent could not complete this request.' );
+		} finally {
+			$this->isLoading = false;
+		}
+	}
+
+	/**
+	 * Emit the suggestion back to the parent editor.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return void
+	 */
+	public function accept(): void
+	{
+		if ( null === $this->suggestedType ) {
+			return;
+		}
+
+		$this->dispatch( 'seo-ai-schema-selected', type: $this->suggestedType, jsonld: $this->jsonld );
+	}
+
+	/**
+	 * Determine whether this feature is enabled in the registry.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return bool
+	 */
+	public function getIsEnabledProperty(): bool
+	{
+		$registry = app( FeatureRegistry::class );
+		$key      = 'seo.generate_schema';
+
+		if ( null === $registry->get( $key ) ) {
+			return false;
+		}
+
+		return $registry->isToggleOn( $key );
+	}
+
+	/**
+	 * Render the component view.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return View
+	 */
+	public function render(): View
+	{
+		return view( 'seo::livewire.ai.schema-suggestor' );
+	}
+}

--- a/src/Providers/SEOServiceProvider.php
+++ b/src/Providers/SEOServiceProvider.php
@@ -17,10 +17,20 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\SEO\Providers;
 
+use ArtisanPackUI\SEO\Ai\Agents\ContentAnalysisAgent;
+use ArtisanPackUI\SEO\Ai\Agents\HreflangSuggestionAgent;
+use ArtisanPackUI\SEO\Ai\Agents\MetaDescriptionAgent;
+use ArtisanPackUI\SEO\Ai\Agents\MetaTitleSuggestionAgent;
+use ArtisanPackUI\SEO\Ai\Agents\SchemaGenerationAgent;
 use ArtisanPackUI\SEO\Console\Commands\GenerateSitemapCommand;
 use ArtisanPackUI\SEO\Console\Commands\InstallFrontend;
 use ArtisanPackUI\SEO\Console\Commands\SubmitSitemapCommand;
 use ArtisanPackUI\SEO\Http\Middleware\HandleRedirects;
+use ArtisanPackUI\SEO\Livewire\Ai\ContentAnalyzer;
+use ArtisanPackUI\SEO\Livewire\Ai\HreflangSuggestor;
+use ArtisanPackUI\SEO\Livewire\Ai\MetaDescriptionSuggestor;
+use ArtisanPackUI\SEO\Livewire\Ai\MetaTitleSuggestor;
+use ArtisanPackUI\SEO\Livewire\Ai\SchemaSuggestor;
 use ArtisanPackUI\SEO\Livewire\HreflangEditor;
 use ArtisanPackUI\SEO\Livewire\Partials\MetaPreview;
 use ArtisanPackUI\SEO\Livewire\Partials\SocialPreview;
@@ -106,6 +116,88 @@ class SEOServiceProvider extends ServiceProvider
 		$this->registerMiddleware();
 		$this->registerMediaLibraryImageSize();
 		$this->registerVisualEditorPrePublishChecks();
+		$this->registerAiGate();
+	}
+
+	/**
+	 * Declare AI features owned by this package.
+	 *
+	 * Auto-discovered by artisanpack-ui/ai when the ai package is installed.
+	 * Each entry maps a fully-qualified feature key to the agent class that
+	 * fulfills it, along with a human-readable label and description for the
+	 * admin UI.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function aiFeatures(): array
+	{
+		return [
+			'seo.suggest_meta_title'       => [
+				'agent'       => MetaTitleSuggestionAgent::class,
+				'package'     => 'artisanpack-ui/seo',
+				'label'       => __( 'Suggest meta title' ),
+				'description' => __( 'Generate 3-5 SEO title variants (≤60 chars) optimized for CTR and keyword coverage.' ),
+			],
+			'seo.suggest_meta_description' => [
+				'agent'       => MetaDescriptionAgent::class,
+				'package'     => 'artisanpack-ui/seo',
+				'label'       => __( 'Suggest meta description' ),
+				'description' => __( 'Generate one 150-160 character meta description that naturally includes the primary keyword.' ),
+			],
+			'seo.analyze_content'          => [
+				'agent'       => ContentAnalysisAgent::class,
+				'package'     => 'artisanpack-ui/seo',
+				'label'       => __( 'Analyze content' ),
+				'description' => __( 'Score content quality across keyword usage, readability, structure, and semantic completeness.' ),
+			],
+			'seo.generate_schema'          => [
+				'agent'       => SchemaGenerationAgent::class,
+				'package'     => 'artisanpack-ui/seo',
+				'label'       => __( 'Suggest schema' ),
+				'description' => __( 'Pick a JSON-LD schema.org type from the supported list and produce a starter structure.' ),
+			],
+			'seo.suggest_hreflang'         => [
+				'agent'       => HreflangSuggestionAgent::class,
+				'package'     => 'artisanpack-ui/seo',
+				'label'       => __( 'Suggest hreflang fixes' ),
+				'description' => __( 'Cross-reference hreflang relationships and surface missing or inconsistent tags.' ),
+			],
+		];
+	}
+
+	/**
+	 * Register the default `seo.ai.use` authorization gate.
+	 *
+	 * The AI API endpoints (`/api/seo/ai/*`) gate on this ability so that
+	 * paid quota isn't spent by every authenticated user. Ships with a
+	 * permissive default (any authenticated user can use AI features) so
+	 * upgrades are non-breaking; installers should override this gate in
+	 * their own `AuthServiceProvider` to enforce a stricter policy —
+	 * e.g. limit to editors/admins or apply per-tenant quotas.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return void
+	 */
+	protected function registerAiGate(): void
+	{
+		$gate = \Illuminate\Support\Facades\Gate::getFacadeRoot();
+
+		// Guard so an installer who registered their own `seo.ai.use`
+		// before our boot() (via a plugin, package-first AuthServiceProvider,
+		// etc.) is not silently overwritten by the permissive default.
+		if ( method_exists( $gate, 'has' ) && $gate->has( 'seo.ai.use' ) ) {
+			return;
+		}
+
+		\Illuminate\Support\Facades\Gate::define(
+			'seo.ai.use',
+			static function ( $user = null ): bool {
+				return null !== $user;
+			},
+		);
 	}
 
 	/**
@@ -359,6 +451,12 @@ class SEOServiceProvider extends ServiceProvider
 		Livewire::component( 'seo::hreflang-editor', HreflangEditor::class );
 		Livewire::component( 'seo::meta-preview', MetaPreview::class );
 		Livewire::component( 'seo::social-preview', SocialPreview::class );
+
+		Livewire::component( 'seo::ai-meta-title-suggestor', MetaTitleSuggestor::class );
+		Livewire::component( 'seo::ai-meta-description-suggestor', MetaDescriptionSuggestor::class );
+		Livewire::component( 'seo::ai-content-analyzer', ContentAnalyzer::class );
+		Livewire::component( 'seo::ai-schema-suggestor', SchemaSuggestor::class );
+		Livewire::component( 'seo::ai-hreflang-suggestor', HreflangSuggestor::class );
 	}
 
 	/**

--- a/tests/Feature/Ai/AiAgentTestSetup.php
+++ b/tests/Feature/Ai/AiAgentTestSetup.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Shared setup helpers for SEO AI agent tests.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace Tests\Feature\Ai;
+
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Contracts\CredentialResolver;
+use ArtisanPackUI\Ai\Credentials\ChainedCredentialResolver;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use Tests\Support\FakeAgentPrompter;
+
+/**
+ * Registers a fake prompter and stub credentials for the 5 SEO features.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.2.0
+ */
+class AiAgentTestSetup
+{
+	/**
+	 * Prepare the container so agents can run against a fake prompter.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  \Illuminate\Foundation\Application  $app  Application instance.
+	 *
+	 * @return FakeAgentPrompter The bound fake prompter.
+	 */
+	public static function bootstrap( $app ): FakeAgentPrompter
+	{
+		/** @var ChainedCredentialResolver $resolver */
+		$resolver = $app->make( CredentialResolver::class );
+		$resolver->setOverride(
+			new Credentials( provider: 'anthropic', apiKey: 'sk-test', defaultModel: 'claude-haiku-4-5' ),
+		);
+		$resolver->useStore( fn () => null );
+
+		$prompter = new FakeAgentPrompter();
+		$app->instance( AgentPrompter::class, $prompter );
+
+		foreach (
+			[
+				'seo.suggest_meta_title',
+				'seo.suggest_meta_description',
+				'seo.analyze_content',
+				'seo.generate_schema',
+				'seo.suggest_hreflang',
+			] as $key
+		) {
+			$app['config']->set( "artisanpack.ai.features.{$key}.enabled", true );
+		}
+
+		return $prompter;
+	}
+}

--- a/tests/Feature/Ai/ContentAnalysisAgentTest.php
+++ b/tests/Feature/Ai/ContentAnalysisAgentTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\SEO\Ai\Agents\ContentAnalysisAgent;
+use Tests\Feature\Ai\AiAgentTestSetup;
+
+beforeEach( function (): void {
+	$this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+it( 'returns the shaped analysis when the prompter responds', function (): void {
+	$dimension = static fn ( int $score ): array => [
+		'score'           => $score,
+		'recommendations' => [ 'Do the thing' ],
+	];
+
+	$this->prompter->queue( [
+		'overall_score' => 82,
+		'dimensions'    => [
+			'keyword_usage'         => $dimension( 90 ),
+			'readability'           => $dimension( 75 ),
+			'structure'             => $dimension( 80 ),
+			'semantic_completeness' => $dimension( 85 ),
+		],
+	] );
+
+	$result = ContentAnalysisAgent::for( [
+		'content'         => 'Sample article body.',
+		'primary_keyword' => 'sample',
+	] )->run();
+
+	expect( $result['overall_score'] )->toBe( 82 );
+	expect( array_keys( $result['dimensions'] ) )->toBe( [
+		'keyword_usage',
+		'readability',
+		'structure',
+		'semantic_completeness',
+	] );
+	expect( $result['dimensions']['keyword_usage']['score'] )->toBe( 90 );
+} );
+
+it( 'clamps out-of-range scores', function (): void {
+	$this->prompter->queue( [
+		'overall_score' => 150,
+		'dimensions'    => [
+			'keyword_usage'         => [ 'score' => -10, 'recommendations' => [ 'x' ] ],
+			'readability'           => [ 'score' => 200, 'recommendations' => [ 'y' ] ],
+			'structure'             => [ 'score' => 50, 'recommendations' => [ 'z' ] ],
+			'semantic_completeness' => [ 'score' => 50, 'recommendations' => [ 'w' ] ],
+		],
+	] );
+
+	$result = ContentAnalysisAgent::for( [
+		'content'         => 'sample',
+		'primary_keyword' => 'sample',
+	] )->run();
+
+	expect( $result['overall_score'] )->toBe( 100 );
+	expect( $result['dimensions']['keyword_usage']['score'] )->toBe( 0 );
+	expect( $result['dimensions']['readability']['score'] )->toBe( 100 );
+} );
+
+it( 'fills missing dimensions with empty defaults', function (): void {
+	$this->prompter->queue( [
+		'overall_score' => 40,
+		'dimensions'    => [
+			'keyword_usage' => [ 'score' => 40, 'recommendations' => [ 'a' ] ],
+		],
+	] );
+
+	$result = ContentAnalysisAgent::for( [
+		'content'         => 'sample',
+		'primary_keyword' => 'sample',
+	] )->run();
+
+	expect( $result['dimensions']['readability']['score'] )->toBe( 0 );
+	expect( $result['dimensions']['readability']['recommendations'] )->toBe( [] );
+} );
+
+it( 'raises FeatureError when primary_keyword is missing', function (): void {
+	expect( fn () => ContentAnalysisAgent::for( [ 'content' => 'sample' ] )->run() )
+		->toThrow( FeatureError::class );
+} );
+
+it( 'unwraps the buggy response where the full payload is wrapped inside dimensions as an object', function (): void {
+	// Second-observed shape: `dimensions` is an OBJECT (not a string) that
+	// contains the full intended top-level payload one level too deep.
+	$innerPayload = [
+		'overall_score' => 32,
+		'dimensions'    => [
+			'keyword_usage'         => [ 'score' => 45, 'recommendations' => [ 'Add keyword to opening sentence' ] ],
+			'readability'           => [ 'score' => 55, 'recommendations' => [ 'Expand section 2' ] ],
+			'structure'             => [ 'score' => 30, 'recommendations' => [ 'Add H3 headings' ] ],
+			'semantic_completeness' => [ 'score' => 25, 'recommendations' => [ 'Cover static and dose retention' ] ],
+		],
+	];
+
+	$this->prompter->queue( [
+		'dimensions' => $innerPayload,
+	] );
+
+	$result = ContentAnalysisAgent::for( [
+		'content'         => 'sample',
+		'primary_keyword' => 'sample',
+	] )->run();
+
+	expect( $result['overall_score'] )->toBe( 32 );
+	expect( $result['dimensions']['structure']['score'] )->toBe( 30 );
+	expect( $result['dimensions']['structure']['recommendations'] )
+		->toBe( [ 'Add H3 headings' ] );
+} );
+
+it( 'unwraps the buggy response where dimensions is a stringified dimensions-only map with score at top level', function (): void {
+	// Third-observed shape: `overall_score` is reported honestly at the top
+	// level, but `dimensions` is a stringified JSON of just the dimensions
+	// map (no nested `overall_score` inside the string).
+	$dimensionsOnly = [
+		'keyword_usage'         => [ 'score' => 60, 'recommendations' => [ 'Use keyword in H1' ] ],
+		'readability'           => [ 'score' => 40, 'recommendations' => [ 'Shorten paragraph 2' ] ],
+		'structure'             => [ 'score' => 35, 'recommendations' => [ 'Add H3 headings' ] ],
+		'semantic_completeness' => [ 'score' => 30, 'recommendations' => [ 'Cover static' ] ],
+	];
+
+	$this->prompter->queue( [
+		'overall_score' => 41,
+		'dimensions'    => json_encode( $dimensionsOnly ),
+	] );
+
+	$result = ContentAnalysisAgent::for( [
+		'content'         => 'sample',
+		'primary_keyword' => 'sample',
+	] )->run();
+
+	expect( $result['overall_score'] )->toBe( 41 );
+	expect( $result['dimensions']['keyword_usage']['score'] )->toBe( 60 );
+	expect( $result['dimensions']['structure']['recommendations'] )
+		->toBe( [ 'Add H3 headings' ] );
+} );
+
+it( 'unwraps the buggy laravel/ai response where dimensions is a stringified full payload', function (): void {
+	// This is the exact shape observed in the wild: laravel/ai's structured-
+	// output bridge stuffs the entire response as a JSON string into the
+	// `dimensions` field. The agent should recover, not score 0/100 across
+	// the board.
+	$innerPayload = [
+		'overall_score' => 42,
+		'dimensions'    => [
+			'keyword_usage'         => [ 'score' => 55, 'recommendations' => [ 'Reuse the primary keyword in section 1' ] ],
+			'readability'           => [ 'score' => 45, 'recommendations' => [ 'Shorten the 32-word sentence' ] ],
+			'structure'             => [ 'score' => 30, 'recommendations' => [ 'Convert Section 1 to an H2' ] ],
+			'semantic_completeness' => [ 'score' => 25, 'recommendations' => [ 'Cover static and dose retention' ] ],
+		],
+	];
+
+	$this->prompter->queue( [
+		'dimensions' => json_encode( $innerPayload ),
+	] );
+
+	$result = ContentAnalysisAgent::for( [
+		'content'         => 'sample',
+		'primary_keyword' => 'sample',
+	] )->run();
+
+	expect( $result['overall_score'] )->toBe( 42 );
+	expect( $result['dimensions']['keyword_usage']['score'] )->toBe( 55 );
+	expect( $result['dimensions']['keyword_usage']['recommendations'] )
+		->toBe( [ 'Reuse the primary keyword in section 1' ] );
+	expect( $result['dimensions']['structure']['recommendations'] )
+		->toBe( [ 'Convert Section 1 to an H2' ] );
+} );

--- a/tests/Feature/Ai/FeatureRegistryTest.php
+++ b/tests/Feature/Ai/FeatureRegistryTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\SEO\Ai\Agents\ContentAnalysisAgent;
+use ArtisanPackUI\SEO\Ai\Agents\HreflangSuggestionAgent;
+use ArtisanPackUI\SEO\Ai\Agents\MetaDescriptionAgent;
+use ArtisanPackUI\SEO\Ai\Agents\MetaTitleSuggestionAgent;
+use ArtisanPackUI\SEO\Ai\Agents\SchemaGenerationAgent;
+use Tests\Feature\Ai\AiAgentTestSetup;
+
+beforeEach( function (): void {
+	$this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+it( 'auto-registers all five SEO features via aiFeatures()', function (): void {
+	/** @var FeatureRegistry $registry */
+	$registry = app( FeatureRegistry::class );
+
+	$expected = [
+		'seo.suggest_meta_title'       => MetaTitleSuggestionAgent::class,
+		'seo.suggest_meta_description' => MetaDescriptionAgent::class,
+		'seo.analyze_content'          => ContentAnalysisAgent::class,
+		'seo.generate_schema'          => SchemaGenerationAgent::class,
+		'seo.suggest_hreflang'         => HreflangSuggestionAgent::class,
+	];
+
+	foreach ( $expected as $key => $class ) {
+		$definition = $registry->get( $key );
+
+		expect( $definition )->not->toBeNull( "feature {$key} was not registered" );
+		expect( $definition->agentClass )->toBe( $class );
+		expect( $definition->package )->toBe( 'artisanpack-ui/seo' );
+	}
+} );
+
+it( 'refuses to run when the feature toggle is off', function (): void {
+	/** @var FeatureRegistry $registry */
+	$registry = app( FeatureRegistry::class );
+	$registry->disable( 'seo.suggest_meta_title' );
+
+	expect( fn () => MetaTitleSuggestionAgent::for( [ 'content' => 'sample' ] )->run() )
+		->toThrow( FeatureDisabledException::class );
+} );

--- a/tests/Feature/Ai/HreflangSuggestionAgentTest.php
+++ b/tests/Feature/Ai/HreflangSuggestionAgentTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\SEO\Ai\Agents\HreflangSuggestionAgent;
+use Tests\Feature\Ai\AiAgentTestSetup;
+
+beforeEach( function (): void {
+	$this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+it( 'short-circuits when no pages are provided', function (): void {
+	$result = HreflangSuggestionAgent::for( [ 'pages' => [] ] )->run();
+
+	expect( $result )->toBe( [ 'issues' => [] ] );
+	expect( $this->prompter->calls )->toBeEmpty();
+} );
+
+it( 'returns the shaped issues when the prompter responds', function (): void {
+	$this->prompter->queue( [
+		'issues' => [
+			[
+				'page_url'           => 'https://example.com/en',
+				'issue_type'         => 'missing_reciprocal',
+				'suggested_hreflang' => [
+					[ 'lang' => 'en', 'url' => 'https://example.com/en' ],
+					[ 'lang' => 'fr', 'url' => 'https://example.com/fr' ],
+				],
+			],
+		],
+	] );
+
+	$result = HreflangSuggestionAgent::for( [
+		'pages' => [
+			[
+				'url'          => 'https://example.com/en',
+				'lang'         => 'en',
+				'translations' => [
+					[ 'url' => 'https://example.com/fr', 'lang' => 'fr' ],
+				],
+			],
+		],
+	] )->run();
+
+	expect( $result['issues'] )->toHaveCount( 1 );
+	expect( $result['issues'][0]['issue_type'] )->toBe( 'missing_reciprocal' );
+	expect( $result['issues'][0]['suggested_hreflang'] )->toHaveCount( 2 );
+} );
+
+it( 'drops issues with unknown issue types', function (): void {
+	$this->prompter->queue( [
+		'issues' => [
+			[
+				'page_url'           => 'https://example.com/en',
+				'issue_type'         => 'unknown_type',
+				'suggested_hreflang' => [],
+			],
+			[
+				'page_url'           => 'https://example.com/fr',
+				'issue_type'         => 'missing_self',
+				'suggested_hreflang' => [
+					[ 'lang' => 'fr', 'url' => 'https://example.com/fr' ],
+				],
+			],
+		],
+	] );
+
+	$result = HreflangSuggestionAgent::for( [
+		'pages' => [
+			[ 'url' => 'https://example.com/fr', 'lang' => 'fr', 'translations' => [] ],
+		],
+	] )->run();
+
+	expect( $result['issues'] )->toHaveCount( 1 );
+	expect( $result['issues'][0]['issue_type'] )->toBe( 'missing_self' );
+} );
+
+it( 'skips pages missing a url or lang', function (): void {
+	$this->prompter->queue( [ 'issues' => [] ] );
+
+	HreflangSuggestionAgent::for( [
+		'pages' => [
+			[ 'url' => '', 'lang' => 'en', 'translations' => [] ],
+			[ 'url' => 'https://example.com', 'lang' => '', 'translations' => [] ],
+			[ 'url' => 'https://example.com/en', 'lang' => 'en', 'translations' => [] ],
+		],
+	] )->run();
+
+	$message = $this->prompter->calls[0]['message'][0]['text'];
+	expect( $message )->toContain( 'https://example.com/en' );
+	expect( substr_count( $message, 'https://example.com' ) )->toBe( 1 );
+} );

--- a/tests/Feature/Ai/MetaDescriptionAgentTest.php
+++ b/tests/Feature/Ai/MetaDescriptionAgentTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\SEO\Ai\Agents\MetaDescriptionAgent;
+use Tests\Feature\Ai\AiAgentTestSetup;
+
+beforeEach( function (): void {
+	$this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+it( 'returns the shaped suggestion when the prompter responds', function (): void {
+	$description = str_pad( 'Discover the best espresso grinders reviewed. ', 158, 'a' );
+
+	$this->prompter->queue( [
+		'meta_description' => $description,
+		'character_count'  => mb_strlen( $description ),
+		'rationale'        => 'benefit-forward summary',
+	] );
+
+	$result = MetaDescriptionAgent::for( [
+		'content'         => 'Long article about espresso grinders.',
+		'primary_keyword' => 'espresso grinder',
+	] )->run();
+
+	expect( $result['meta_description'] )->toBe( $description );
+	expect( $result['character_count'] )->toBe( mb_strlen( $description ) );
+	expect( $result['rationale'] )->toBe( 'benefit-forward summary' );
+} );
+
+it( 'clamps oversized descriptions to 160 characters', function (): void {
+	$oversize = str_repeat( 'x', 200 );
+
+	$this->prompter->queue( [
+		'meta_description' => $oversize,
+		'character_count'  => 200,
+		'rationale'        => '',
+	] );
+
+	$result = MetaDescriptionAgent::for( [ 'content' => 'sample' ] )->run();
+
+	expect( mb_strlen( $result['meta_description'] ) )->toBe( 160 );
+	expect( $result['character_count'] )->toBe( 160 );
+} );
+
+it( 'raises FeatureError when content is missing', function (): void {
+	expect( fn () => MetaDescriptionAgent::for( [] )->run() )
+		->toThrow( FeatureError::class );
+} );
+
+it( 'forwards primary_keyword into the prompter message', function (): void {
+	$this->prompter->queue( [
+		'meta_description' => 'x',
+		'character_count'  => 1,
+		'rationale'        => '',
+	] );
+
+	MetaDescriptionAgent::for( [
+		'content'         => 'sample',
+		'primary_keyword' => 'espresso grinder',
+	] )->run();
+
+	$parts = collect( $this->prompter->calls[0]['message'] )->pluck( 'text' );
+	expect( $parts->contains( fn ( string $text ): bool => str_contains( $text, 'espresso grinder' ) ) )
+		->toBeTrue();
+} );

--- a/tests/Feature/Ai/MetaTitleSuggestionAgentTest.php
+++ b/tests/Feature/Ai/MetaTitleSuggestionAgentTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\SEO\Ai\Agents\MetaTitleSuggestionAgent;
+use Tests\Feature\Ai\AiAgentTestSetup;
+
+beforeEach( function (): void {
+	$this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+it( 'returns the shaped variants when the prompter responds', function (): void {
+	$this->prompter->queue( [
+		'variants' => [
+			[ 'title' => 'Best Coffee Grinders for Espresso', 'char_count' => 33, 'rationale' => 'benefit-forward' ],
+			[ 'title' => 'Espresso Grinder Buying Guide 2026', 'char_count' => 34, 'rationale' => 'guide framing' ],
+			[ 'title' => 'How to Pick an Espresso Grinder', 'char_count' => 31, 'rationale' => 'how-to lens' ],
+		],
+	] );
+
+	$result = MetaTitleSuggestionAgent::for( [
+		'content'         => 'A long article about picking the right grinder for espresso.',
+		'primary_keyword' => 'espresso grinder',
+		'brand'           => 'Acme',
+	] )->run();
+
+	expect( $result['variants'] )->toHaveCount( 3 );
+	expect( $result['variants'][0]['title'] )->toBe( 'Best Coffee Grinders for Espresso' );
+	expect( $result['variants'][0]['char_count'] )->toBe( 33 );
+} );
+
+it( 'clamps oversized titles down to 60 characters', function (): void {
+	$oversize = str_repeat( 'x', 80 );
+
+	$this->prompter->queue( [
+		'variants' => [
+			[ 'title' => $oversize, 'char_count' => 80, 'rationale' => 'too long on purpose' ],
+			[ 'title' => 'Normal Title', 'char_count' => 12, 'rationale' => 'baseline' ],
+			[ 'title' => 'Another Title', 'char_count' => 13, 'rationale' => 'baseline' ],
+		],
+	] );
+
+	$result = MetaTitleSuggestionAgent::for( [
+		'content' => 'sample',
+	] )->run();
+
+	expect( mb_strlen( $result['variants'][0]['title'] ) )->toBe( 60 );
+	expect( $result['variants'][0]['char_count'] )->toBe( 60 );
+} );
+
+it( 'drops variants with an empty title', function (): void {
+	$this->prompter->queue( [
+		'variants' => [
+			[ 'title' => '', 'char_count' => 0, 'rationale' => 'empty' ],
+			[ 'title' => 'Real Title', 'char_count' => 10, 'rationale' => 'real' ],
+			[ 'title' => 'Another Real', 'char_count' => 12, 'rationale' => 'real' ],
+			[ 'title' => 'Third Real', 'char_count' => 10, 'rationale' => 'real' ],
+		],
+	] );
+
+	$result = MetaTitleSuggestionAgent::for( [ 'content' => 'sample' ] )->run();
+
+	expect( $result['variants'] )->toHaveCount( 3 );
+} );
+
+it( 'trims variants to at most 5 entries', function (): void {
+	$this->prompter->queue( [
+		'variants' => array_map(
+			static fn ( int $i ): array => [
+				'title'      => "Title {$i}",
+				'char_count' => 7,
+				'rationale'  => "reason {$i}",
+			],
+			range( 1, 8 ),
+		),
+	] );
+
+	$result = MetaTitleSuggestionAgent::for( [ 'content' => 'sample' ] )->run();
+
+	expect( $result['variants'] )->toHaveCount( 5 );
+} );
+
+it( 'raises FeatureError when content is missing', function (): void {
+	expect( fn () => MetaTitleSuggestionAgent::for( [] )->run() )
+		->toThrow( FeatureError::class );
+} );
+
+it( 'forwards primary_keyword and brand into the prompter message', function (): void {
+	$this->prompter->queue( [
+		'variants' => [
+			[ 'title' => 'A', 'char_count' => 1, 'rationale' => '' ],
+			[ 'title' => 'B', 'char_count' => 1, 'rationale' => '' ],
+			[ 'title' => 'C', 'char_count' => 1, 'rationale' => '' ],
+		],
+	] );
+
+	MetaTitleSuggestionAgent::for( [
+		'content'         => 'sample',
+		'primary_keyword' => 'espresso grinder',
+		'brand'           => 'Acme',
+	] )->run();
+
+	$parts = collect( $this->prompter->calls[0]['message'] )->pluck( 'text' );
+	expect( $parts->contains( fn ( string $text ): bool => str_contains( $text, 'espresso grinder' ) ) )
+		->toBeTrue();
+	expect( $parts->contains( fn ( string $text ): bool => str_contains( $text, 'Acme' ) ) )
+		->toBeTrue();
+} );

--- a/tests/Feature/Ai/SchemaGenerationAgentTest.php
+++ b/tests/Feature/Ai/SchemaGenerationAgentTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\SEO\Ai\Agents\SchemaGenerationAgent;
+use Tests\Feature\Ai\AiAgentTestSetup;
+
+beforeEach( function (): void {
+	$this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+it( 'returns the shaped suggestion when the prompter responds', function (): void {
+	$this->prompter->queue( [
+		'suggested_type'          => 'Article',
+		'confidence'              => 0.87,
+		'jsonld'                  => [
+			'@context' => 'https://schema.org',
+			'@type'    => 'Article',
+			'headline' => 'Espresso Guide',
+			'url'      => 'https://example.com/espresso',
+		],
+		'missing_required_fields' => [ 'author' ],
+	] );
+
+	$result = SchemaGenerationAgent::for( [
+		'content' => 'Article body about espresso.',
+		'title'   => 'Espresso Guide',
+		'url'     => 'https://example.com/espresso',
+	] )->run();
+
+	expect( $result['suggested_type'] )->toBe( 'Article' );
+	expect( $result['confidence'] )->toBe( 0.87 );
+	expect( $result['jsonld']['@type'] )->toBe( 'Article' );
+	expect( $result['missing_required_fields'] )->toBe( [ 'author' ] );
+} );
+
+it( 'falls back to WebPage for unsupported types', function (): void {
+	$this->prompter->queue( [
+		'suggested_type'          => 'SomeUnsupportedType',
+		'confidence'              => 0.5,
+		'jsonld'                  => [ '@context' => 'https://schema.org', '@type' => 'SomeUnsupportedType' ],
+		'missing_required_fields' => [],
+	] );
+
+	$result = SchemaGenerationAgent::for( [
+		'content' => 'sample',
+		'title'   => 'sample',
+	] )->run();
+
+	expect( $result['suggested_type'] )->toBe( 'WebPage' );
+} );
+
+it( 'syncs jsonld @type when suggested_type is coerced', function (): void {
+	// Model returns an unsupported type in BOTH suggested_type and jsonld['@type'];
+	// the agent must coerce jsonld to match the top-level fallback so downstream
+	// callers never emit invalid schema.org markup.
+	$this->prompter->queue( [
+		'suggested_type'          => 'MadeUpType',
+		'confidence'              => 0.4,
+		'jsonld'                  => [
+			'@context' => 'https://schema.org',
+			'@type'    => 'MadeUpType',
+			'headline' => 'Sample',
+		],
+		'missing_required_fields' => [],
+	] );
+
+	$result = SchemaGenerationAgent::for( [
+		'content' => 'sample',
+		'title'   => 'sample',
+	] )->run();
+
+	expect( $result['suggested_type'] )->toBe( 'WebPage' );
+	expect( $result['jsonld']['@type'] )->toBe( 'WebPage' );
+	expect( $result['jsonld']['headline'] )->toBe( 'Sample' );
+} );
+
+it( 'clamps confidence to the 0..1 range', function (): void {
+	$this->prompter->queue( [
+		'suggested_type'          => 'Article',
+		'confidence'              => 2.5,
+		'jsonld'                  => [ '@context' => 'https://schema.org', '@type' => 'Article' ],
+		'missing_required_fields' => [],
+	] );
+
+	$result = SchemaGenerationAgent::for( [
+		'content' => 'sample',
+		'title'   => 'sample',
+	] )->run();
+
+	expect( $result['confidence'] )->toBe( 1.0 );
+} );
+
+it( 'auto-fills the @context and @type keys when the model omits them', function (): void {
+	$this->prompter->queue( [
+		'suggested_type'          => 'Article',
+		'confidence'              => 0.5,
+		'jsonld'                  => [ 'headline' => 'x' ],
+		'missing_required_fields' => [],
+	] );
+
+	$result = SchemaGenerationAgent::for( [
+		'content' => 'sample',
+		'title'   => 'sample',
+	] )->run();
+
+	expect( $result['jsonld']['@context'] )->toBe( 'https://schema.org' );
+	expect( $result['jsonld']['@type'] )->toBe( 'Article' );
+} );
+
+it( 'raises FeatureError when title is missing', function (): void {
+	expect( fn () => SchemaGenerationAgent::for( [ 'content' => 'sample' ] )->run() )
+		->toThrow( FeatureError::class );
+} );

--- a/tests/Support/FakeAgentPrompter.php
+++ b/tests/Support/FakeAgentPrompter.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * Test fake for the AgentPrompter contract.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace Tests\Support;
+
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+
+/**
+ * Records every prompter call and returns queued responses in order.
+ *
+ * Mirrors the dev-app FakeAgentPrompter used by /ai-issues-test surfaces —
+ * kept here so the package's own test suite does not have to depend on the
+ * dev app's source tree.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.2.0
+ */
+final class FakeAgentPrompter implements AgentPrompter
+{
+	/**
+	 * Recorded calls, in invocation order.
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	public array $calls = [];
+
+	/**
+	 * Queued responses (FIFO).
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	private array $queue = [];
+
+	/**
+	 * Push a canned response onto the queue.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  array<string, mixed>  $output        Structured output body.
+	 * @param  int                   $inputTokens   Reported input tokens.
+	 * @param  int                   $outputTokens  Reported output tokens.
+	 *
+	 * @return void
+	 */
+	public function queue( array $output, int $inputTokens = 100, int $outputTokens = 50 ): void
+	{
+		$this->queue[] = [
+			'output'        => $output,
+			'input_tokens'  => $inputTokens,
+			'output_tokens' => $outputTokens,
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function prompt(
+		Credentials $credentials,
+		string $model,
+		string $instructions,
+		string|array $message,
+		array $outputSchema,
+	): array {
+		$this->calls[] = [
+			'credentials'   => $credentials,
+			'model'         => $model,
+			'instructions'  => $instructions,
+			'message'       => $message,
+			'output_schema' => $outputSchema,
+		];
+
+		if ( [] === $this->queue ) {
+			return [
+				'output'        => [],
+				'input_tokens'  => 0,
+				'output_tokens' => 0,
+			];
+		}
+
+		return array_shift( $this->queue );
+	}
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 
 namespace Tests;
 
+use ArtisanPackUI\Ai\AiServiceProvider;
 use ArtisanPackUI\SEO\Providers\SEOServiceProvider;
 use Illuminate\Support\Facades\Blade;
 use Livewire\LivewireServiceProvider;
@@ -90,6 +91,7 @@ abstract class TestCase extends BaseTestCase
     {
         return [
             LivewireServiceProvider::class,
+            AiServiceProvider::class,
             SEOServiceProvider::class,
         ];
     }


### PR DESCRIPTION
## Description

Adds five AI agents to the SEO package, built on top of `artisanpack-ui/ai`. Each agent ships with parity across Livewire, React, and Vue trigger components plus a JSON API endpoint, and is registered with the shared feature registry so admins can toggle each one independently.

**Closes:** #50, #51, #52, #53, #54

## Type of Change

- [x] New feature (adds new functionality)

## Related Issues

- **Issue:** #50 — MetaTitleSuggestionAgent
- **Issue:** #51 — MetaDescriptionAgent
- **Issue:** #52 — ContentAnalysisAgent
- **Issue:** #53 — SchemaGenerationAgent
- **Issue:** #54 — HreflangSuggestionAgent

## Motivation and Context

The [AI RFC](https://github.com/ArtisanPack-UI/.github/discussions/8) landed with `artisanpack-ui/ai` v1.0.0 as the foundation. These five SEO features are the first-party consumers on top of that foundation and cover the workflow most SEO editors ask for: title/description generation, a smarter content analyzer, JSON-LD scaffolding, and hreflang gap detection.

Bundling the five agents in a single PR (rather than five 1-file PRs) is deliberate — they share the same registration surface, API controller, feature-registry wiring, Livewire event contracts, and React/Vue shared hooks, and are easier to review as one unit.

## Changes Made

**Agents (`src/Ai/Agents/`):**
- `MetaTitleSuggestionAgent` — 3–5 title variants ≤60 chars with per-variant rationale (#50)
- `MetaDescriptionAgent` — one 150–160 char meta description with rationale (#51)
- `ContentAnalysisAgent` — 4-dimension quality score + imperative recommendations (#52)
- `SchemaGenerationAgent` — schema.org type suggestion + starter JSON-LD (#53)
- `HreflangSuggestionAgent` — surfaces missing/inconsistent hreflang relationships (#54)

**API layer (`src/Http/`):**
- `AiAgentApiController` with 5 endpoints under `/api/seo/ai/*`
- Dedicated `FormRequest` per endpoint under `Http/Requests/Api/Ai/`
- Structured error status codes (404/409/412/422/500) mapped from ai package exceptions

**Livewire triggers (`src/Livewire/Ai/`):**
- 5 self-contained components tagged `<livewire:seo::ai-*-suggestor>` / `<livewire:seo::ai-content-analyzer>`
- Unified `seo-ai-context-updated` event listener across all 5
- Emit typed selection events (`seo-ai-title-selected`, etc.) with snake_case named args matching the rest of the package
- Robust `Throwable` catch → in-panel error banner (no more raw 500s if the provider hiccups)

**React & Vue triggers (`resources/js/{react,vue}/`):**
- `useAiAgent` hook (React) + composable (Vue) layering on the existing `useApi`
- 5 mirrored components under `components/ai/` on each stack, with full type exports from the top-level `index.ts`

**Feature registry & policy:**
- `SEOServiceProvider::aiFeatures()` auto-registers all five features with labels + default models
- Default `seo.ai.use` gate registered (permissive so upgrades don't break); installers override in their own `AuthServiceProvider` to gate paid quota per role

**Robustness / correctness fixes surfaced in review:**
- `ContentAnalysisAgent::findPayload()` recovers three observed `laravel/ai` structured-output bug shapes where the model's response is misrouted into a wrong-typed field (this is what unblocks #52 against real Anthropic calls)
- `SchemaGenerationAgent` syncs `jsonld['@type']` when `suggested_type` is coerced to `WebPage` — no more contract mismatch on invalid model output
- `HreflangSuggestionAgent` short-circuits when zero pages are provided

**Dependency:**
- `artisanpack-ui/ai: ^1.0` added to `require`. Path repos are intentionally NOT committed to `composer.json`; `CONTRIBUTING.md` documents the local-dev setup for co-development against the sibling ai checkout.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 25.5.0
- PHP Version: 8.4.3
- Project Version: 1.2.x

**Tests Performed:**
1. Full test suite: 1354 passing, 3164 assertions (up from 1322 before the branch)
2. 32 new Pest tests covering: agent outputs, edge modes (over-length clamps, unknown enums, missing dimensions, empty inputs), feature-registry auto-registration, and the three ContentAnalysis unwrap shapes
3. Manual browser QA in the dev app for all 5 features under both fake and real Anthropic API modes
4. `php-cs-fixer fix` clean; `phpcs` clean (no new warnings)

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** Package templates ship without hard styling assumptions — consumers style the trigger UI. The Livewire views use semantic HTML (`<button>`, `<ul>`, `role="alert"` on errors) but a11y sweep should happen in the consuming app.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** 32 new Pest tests across `tests/Feature/Ai/`. Regression tests specifically cover the three ContentAnalysis unwrap shapes and the SchemaGenerationAgent `@type` sync after coercion.

## Documentation

- [x] Inline code documentation added
- [x] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:**
- README gains an "AI Features" section listing feature keys, default models, and toggle instructions
- CHANGELOG entry under `[Unreleased]`
- CONTRIBUTING gains a local-dev note for the `artisanpack-ui/ai` sibling checkout
- Extensive PHPDoc on every new class + method

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (`php-cs-fixer`)
- [ ] Accessibility tests completed (see note above)
- [x] Code follows project style guide
- [x] Self-review completed (medium-effort multi-agent review; 8 findings surfaced and all 8 fixed in this branch)
- [x] Comments added for complex code (esp. `findPayload`)
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI-powered SEO tools for meta titles, meta descriptions, content analysis, schema suggestions, and hreflang checks.
  * Introduced matching UI actions in Livewire, React, and Vue, plus API endpoints for triggering each workflow.
  * Enabled feature toggles and consistent responses when an AI feature is unavailable.

* **Documentation**
  * Expanded the changelog, README, and contributing guide with setup, usage, and local development notes for AI features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->