### PR TITLE
feat: add ap.seo.metaTags and ap.seo.sitemapEntries filter hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-07-21
+
+### Added
+
+- **`ap.seo.metaTags` filter hook**: Fired in `MetaTagService::generate()` after tags are assembled and before the `MetaTagsDTO` is built. Payload: `(array $tags, ?Model $subject, Request $request)`. Callbacks can add, remove, or rewrite `title`, `description`, `canonical`, `robots`, and `additionalMeta` before rendering (#62).
+- **`ap.seo.sitemapEntries` filter hook**: Fired inside `SitemapGenerator::generate()` and `SitemapGenerator::generateFromProvider()` so integrators can append, drop, or reorder sitemap entries per type. Payload: `(array $entries, string $sitemapType)` (#62).
+
+### Changed
+
+- **`artisanpack-ui/hooks: ^1.3` is now a required dependency** (previously optional). The `PackageDetector::hasHooks()` guard has been removed and the hook helper functions are always available.
+- **Renamed VE subscriber hook**: `VisualEditorIntegration::registerPrePublishChecks()` now subscribes to `ap.visualEditor.prePublishChecks` (matching the visual-editor Wave 3 rename) instead of the old `visual_editor.pre_publish_checks` name.
+
+### Removed
+
+- `PackageDetector::hasHooks()` — no longer needed now that `artisanpack-ui/hooks` is required.
+
 ## [1.2.0] - 2026-07-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -319,20 +319,38 @@ class CustomAnalyzer implements AnalyzerInterface
 
 ### Filter Hooks
 
+The package fires the following filter hooks from the `artisanpack-ui/hooks` package:
+
+| Hook | Fired in | Payload |
+|---|---|---|
+| `ap.seo.metaTags` | `MetaTagService::generate()` | `(array $tags, ?Model $subject, Request $request)` |
+| `ap.seo.sitemapEntries` | `SitemapGenerator::generate()` and `generateFromProvider()` | `(array $entries, string $sitemapType)` |
+
+It also subscribes to `ap.visualEditor.prePublishChecks` (fired by `artisanpack-ui/visual-editor`) to append SEO checks to the pre-publish workflow.
+
 ```php
 use function addFilter;
 
-// Modify meta tags before output
-addFilter('seo.meta_tags', function (array $tags, $model) {
-    $tags['custom-meta'] = 'Custom value';
-    return $tags;
-});
+// Modify meta tags before the DTO is built
+addFilter( 'ap.seo.metaTags', function ( array $tags, ?Model $subject, Request $request ): array {
+    $tags['additionalMeta']['x-custom'] = 'Custom value';
 
-// Add custom sitemap entries
-addFilter('seo.sitemap_entries', function (Collection $entries) {
-    $entries->push(new CustomSitemapEntry());
+    return $tags;
+} );
+
+// Add or remove sitemap entries per sitemap type
+addFilter( 'ap.seo.sitemapEntries', function ( array $entries, string $sitemapType ): array {
+    if ( 'page' === $sitemapType ) {
+        $entries[] = [
+            'url'        => 'https://example.com/extra',
+            'lastmod'    => now()->toIso8601String(),
+            'changefreq' => 'weekly',
+            'priority'   => 0.6,
+        ];
+    }
+
     return $entries;
-});
+} );
 ```
 
 ## Middleware

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "SEO utilities and meta tag management for Laravel applications",
   "type": "library",
   "license": "MIT",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "autoload": {
     "psr-4": {
       "ArtisanPackUI\\SEO\\": "src/"
@@ -26,7 +26,8 @@
   "require": {
     "php": "^8.2",
     "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
-    "artisanpack-ui/core": "^1.0"
+    "artisanpack-ui/core": "^1.0",
+    "artisanpack-ui/hooks": "^1.3"
   },
   "require-dev": {
     "pestphp/pest": "^3.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,80 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bf89642fd8860bff9e5d7e0df6059851",
+    "content-hash": "5cdcd0290b0867507994e85091436f97",
     "packages": [
-        {
-            "name": "artisanpack-ui/ai",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ArtisanPack-UI/ai.git",
-                "reference": "082f1cd337742d34b8035d116c6c5ad8e5453fca"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ArtisanPack-UI/ai/zipball/082f1cd337742d34b8035d116c6c5ad8e5453fca",
-                "reference": "082f1cd337742d34b8035d116c6c5ad8e5453fca",
-                "shasum": ""
-            },
-            "require": {
-                "artisanpack-ui/core": "^1.0",
-                "illuminate/support": "^12.0|^13.0",
-                "laravel/ai": "^0.8",
-                "php": "^8.3"
-            },
-            "require-dev": {
-                "artisanpack-ui/code-style": "^1.1",
-                "artisanpack-ui/code-style-pint": "^1.1",
-                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-                "friendsofphp/php-cs-fixer": "^3.75",
-                "laravel/pint": "^1.26",
-                "livewire/livewire": "^3.6",
-                "orchestra/testbench": "^10.2|^11.0",
-                "pestphp/pest": "^3.8|^4.0",
-                "pestphp/pest-plugin-laravel": "^3.2|^4.1"
-            },
-            "suggest": {
-                "artisanpack-ui/cms-framework": "Automatically registers AI credentials, features, budget and cache setting groups under the CMS admin surface.",
-                "artisanpack-ui/livewire-ui-components": "Renders the AI Settings and Usage admin surfaces using x-artisanpack-* components.",
-                "livewire/livewire": "Required to mount the AI Settings and Usage dashboard Livewire components under cms-framework's admin nav."
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "aliases": {
-                        "Ai": "ArtisanPackUI\\Ai\\Facades\\Ai"
-                    },
-                    "providers": [
-                        "ArtisanPackUI\\Ai\\AiServiceProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/helpers.php"
-                ],
-                "psr-4": {
-                    "ArtisanPackUI\\Ai\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jacob Martella",
-                    "email": "me@jacobmartella.com"
-                }
-            ],
-            "description": "Shared AI foundation for the ArtisanPack UI ecosystem, built on top of laravel/ai.",
-            "support": {
-                "issues": "https://github.com/ArtisanPack-UI/ai/issues",
-                "source": "https://github.com/ArtisanPack-UI/ai/tree/v1.0.0"
-            },
-            "time": "2026-07-06T21:25:38+00:00"
-        },
         {
             "name": "artisanpack-ui/core",
             "version": "1.2.0",
@@ -148,155 +76,70 @@
             "time": "2026-05-24T02:53:50+00:00"
         },
         {
-            "name": "aws/aws-crt-php",
-            "version": "v1.2.7",
+            "name": "artisanpack-ui/hooks",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/awslabs/aws-crt-php.git",
-                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e"
+                "url": "https://github.com/ArtisanPack-UI/hooks.git",
+                "reference": "2834223f643ee5e12f93edc816a6d2dca66d09aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/awslabs/aws-crt-php/zipball/d71d9906c7bb63a28295447ba12e74723bd3730e",
-                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/hooks/zipball/2834223f643ee5e12f93edc816a6d2dca66d09aa",
+                "reference": "2834223f643ee5e12f93edc816a6d2dca66d09aa",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5"
+                "illuminate/support": "^11.0|^12.0|^13.0",
+                "php": "^8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35||^5.6.3||^9.5",
-                "yoast/phpunit-polyfills": "^1.0"
-            },
-            "suggest": {
-                "ext-awscrt": "Make sure you install awscrt native extension to use any of the functionality."
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "AWS SDK Common Runtime Team",
-                    "email": "aws-sdk-common-runtime@amazon.com"
-                }
-            ],
-            "description": "AWS Common Runtime for PHP",
-            "homepage": "https://github.com/awslabs/aws-crt-php",
-            "keywords": [
-                "amazon",
-                "aws",
-                "crt",
-                "sdk"
-            ],
-            "support": {
-                "issues": "https://github.com/awslabs/aws-crt-php/issues",
-                "source": "https://github.com/awslabs/aws-crt-php/tree/v1.2.7"
-            },
-            "time": "2024-10-18T22:15:13+00:00"
-        },
-        {
-            "name": "aws/aws-sdk-php",
-            "version": "3.387.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "20818be961ace3ef01c1aed3c247e71b26020149"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/20818be961ace3ef01c1aed3c247e71b26020149",
-                "reference": "20818be961ace3ef01c1aed3c247e71b26020149",
-                "shasum": ""
-            },
-            "require": {
-                "aws/aws-crt-php": "^1.2.3",
-                "ext-json": "*",
-                "ext-pcre": "*",
-                "ext-simplexml": "*",
-                "guzzlehttp/guzzle": "^7.4.5",
-                "guzzlehttp/promises": "^2.0",
-                "guzzlehttp/psr7": "^2.4.5",
-                "mtdowling/jmespath.php": "^2.9.1",
-                "php": ">=8.1",
-                "psr/http-message": "^1.0 || ^2.0",
-                "symfony/filesystem": "^v5.4.45 || ^v6.4.3 || ^v7.1.0 || ^v8.0.0"
-            },
-            "require-dev": {
-                "andrewsville/php-token-reflection": "^1.4",
-                "aws/aws-php-sns-message-validator": "~1.0",
-                "behat/behat": "~3.0",
-                "composer/composer": "^2.7.8",
-                "dms/phpunit-arraysubset-asserts": "^v0.5.0",
-                "doctrine/cache": "~1.4",
-                "ext-dom": "*",
-                "ext-openssl": "*",
-                "ext-sockets": "*",
-                "phpunit/phpunit": "^10.0",
-                "psr/cache": "^2.0 || ^3.0",
-                "psr/simple-cache": "^2.0 || ^3.0",
-                "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
-                "yoast/phpunit-polyfills": "^2.0"
-            },
-            "suggest": {
-                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
-                "doctrine/cache": "To use the DoctrineCacheAdapter",
-                "ext-curl": "To send requests using cURL",
-                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
-                "ext-pcntl": "To use client-side monitoring",
-                "ext-sockets": "To use client-side monitoring"
+                "artisanpack-ui/code-style": "^1.0",
+                "artisanpack-ui/code-style-pint": "^1.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.1",
+                "laravel/pint": "^1.25",
+                "orchestra/testbench": "^10.6",
+                "pestphp/pest": "^3.8",
+                "pestphp/pest-plugin-laravel": "^3.1",
+                "squizlabs/php_codesniffer": "^3.13"
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
+                "laravel": {
+                    "aliases": {
+                        "Action": "ArtisanPackUI\\Hooks\\Facades\\Action",
+                        "Filter": "ArtisanPackUI\\Hooks\\Facades\\Filter"
+                    },
+                    "providers": [
+                        "ArtisanPackUI\\Hooks\\Providers\\HooksServiceProvider",
+                        "ArtisanPackUI\\Hooks\\Providers\\BladeDirectiveServiceProvider"
+                    ]
                 }
             },
             "autoload": {
                 "files": [
-                    "src/functions.php"
+                    "src/helpers.php"
                 ],
                 "psr-4": {
-                    "Aws\\": "src/"
-                },
-                "exclude-from-classmap": [
-                    "src/data/"
-                ]
+                    "ArtisanPackUI\\Hooks\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "Apache-2.0"
+                "MIT"
             ],
             "authors": [
                 {
-                    "name": "Amazon Web Services",
-                    "homepage": "https://aws.amazon.com"
+                    "name": "Jacob Martella",
+                    "email": "me@jacobmartella.com"
                 }
             ],
-            "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
-            "homepage": "https://aws.amazon.com/sdk-for-php",
-            "keywords": [
-                "amazon",
-                "aws",
-                "cloud",
-                "dynamodb",
-                "ec2",
-                "glacier",
-                "s3",
-                "sdk"
-            ],
+            "description": "WordPress-style actions and filters for Laravel, with Blade directives and helper functions.",
             "support": {
-                "forum": "https://github.com/aws/aws-sdk-php/discussions",
-                "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.387.3"
+                "issues": "https://github.com/ArtisanPack-UI/hooks/issues",
+                "source": "https://github.com/ArtisanPack-UI/hooks/tree/v1.3.0"
             },
-            "time": "2026-07-06T18:13:24+00:00"
+            "time": "2026-07-20T18:37:59+00:00"
         },
         {
             "name": "brick/math",
@@ -1428,80 +1271,6 @@
             "time": "2026-05-23T22:00:21+00:00"
         },
         {
-            "name": "laravel/ai",
-            "version": "v0.8.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laravel/ai.git",
-                "reference": "b23bc857576d7c4b3bb52ffd8be936ae74005d23"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laravel/ai/zipball/b23bc857576d7c4b3bb52ffd8be936ae74005d23",
-                "reference": "b23bc857576d7c4b3bb52ffd8be936ae74005d23",
-                "shasum": ""
-            },
-            "require": {
-                "aws/aws-sdk-php": "^3.339",
-                "illuminate/console": "^12.0|^13.0",
-                "illuminate/container": "^12.0|^13.0",
-                "illuminate/contracts": "^12.0|^13.0",
-                "illuminate/database": "^12.0|^13.0",
-                "illuminate/filesystem": "^12.0|^13.0",
-                "illuminate/json-schema": "^12.62|^13.15",
-                "illuminate/support": "^12.0|^13.0",
-                "laravel/prompts": "^0.3.6",
-                "laravel/serializable-closure": "^2.0",
-                "php": "^8.3"
-            },
-            "require-dev": {
-                "laravel/mcp": "^0.8",
-                "laravel/pint": "^1.26",
-                "mockery/mockery": "^1.6.12",
-                "orchestra/testbench": "^10.6|^11.0",
-                "pestphp/pest": "^3.0|^4.0",
-                "pestphp/pest-plugin-laravel": "^3.0|^4.0",
-                "phpstan/phpstan": "^2.1"
-            },
-            "suggest": {
-                "laravel/mcp": "Required to use MCP client tools or MCP server tools with Laravel AI agents."
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "providers": [
-                        "Laravel\\Ai\\AiServiceProvider"
-                    ]
-                },
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "functions.php"
-                ],
-                "psr-4": {
-                    "Laravel\\Ai\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "The official AI SDK for Laravel.",
-            "homepage": "https://github.com/laravel/ai",
-            "keywords": [
-                "ai",
-                "laravel"
-            ],
-            "support": {
-                "issues": "https://github.com/laravel/ai/issues",
-                "source": "https://github.com/laravel/ai"
-            },
-            "time": "2026-06-10T11:23:35+00:00"
-        },
-        {
             "name": "laravel/framework",
             "version": "v12.62.0",
             "source": {
@@ -2504,72 +2273,6 @@
                 }
             ],
             "time": "2026-01-02T08:56:05+00:00"
-        },
-        {
-            "name": "mtdowling/jmespath.php",
-            "version": "2.9.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/jmespath/jmespath.php.git",
-                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
-                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2.5 || ^8.0",
-                "symfony/polyfill-mbstring": "^1.17"
-            },
-            "require-dev": {
-                "composer/xdebug-handler": "^3.0.3",
-                "phpunit/phpunit": "^8.5.52"
-            },
-            "bin": [
-                "bin/jp.php"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.9-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/JmesPath.php"
-                ],
-                "psr-4": {
-                    "JmesPath\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Graham Campbell",
-                    "email": "hello@gjcampbell.co.uk",
-                    "homepage": "https://github.com/GrahamCampbell"
-                },
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Declaratively specify how to extract elements from a JSON document",
-            "keywords": [
-                "json",
-                "jsonpath"
-            ],
-            "support": {
-                "issues": "https://github.com/jmespath/jmespath.php/issues",
-                "source": "https://github.com/jmespath/jmespath.php/tree/2.9.2"
-            },
-            "time": "2026-07-06T18:56:19+00:00"
         },
         {
             "name": "nesbot/carbon",
@@ -4168,77 +3871,6 @@
                 }
             ],
             "time": "2026-01-05T13:30:16+00:00"
-        },
-        {
-            "name": "symfony/filesystem",
-            "version": "v8.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/filesystem.git",
-                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/99aec13b82b4967ec5088222c4a3ecca955949c2",
-                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.4.1",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-mbstring": "~1.8"
-            },
-            "require-dev": {
-                "symfony/process": "^7.4|^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Filesystem\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides basic utilities for the filesystem",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v8.1.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/finder",
@@ -6394,6 +6026,78 @@
     ],
     "packages-dev": [
         {
+            "name": "artisanpack-ui/ai",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ArtisanPack-UI/ai.git",
+                "reference": "082f1cd337742d34b8035d116c6c5ad8e5453fca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/ai/zipball/082f1cd337742d34b8035d116c6c5ad8e5453fca",
+                "reference": "082f1cd337742d34b8035d116c6c5ad8e5453fca",
+                "shasum": ""
+            },
+            "require": {
+                "artisanpack-ui/core": "^1.0",
+                "illuminate/support": "^12.0|^13.0",
+                "laravel/ai": "^0.8",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "artisanpack-ui/code-style": "^1.1",
+                "artisanpack-ui/code-style-pint": "^1.1",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "friendsofphp/php-cs-fixer": "^3.75",
+                "laravel/pint": "^1.26",
+                "livewire/livewire": "^3.6",
+                "orchestra/testbench": "^10.2|^11.0",
+                "pestphp/pest": "^3.8|^4.0",
+                "pestphp/pest-plugin-laravel": "^3.2|^4.1"
+            },
+            "suggest": {
+                "artisanpack-ui/cms-framework": "Automatically registers AI credentials, features, budget and cache setting groups under the CMS admin surface.",
+                "artisanpack-ui/livewire-ui-components": "Renders the AI Settings and Usage admin surfaces using x-artisanpack-* components.",
+                "livewire/livewire": "Required to mount the AI Settings and Usage dashboard Livewire components under cms-framework's admin nav."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Ai": "ArtisanPackUI\\Ai\\Facades\\Ai"
+                    },
+                    "providers": [
+                        "ArtisanPackUI\\Ai\\AiServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "ArtisanPackUI\\Ai\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jacob Martella",
+                    "email": "me@jacobmartella.com"
+                }
+            ],
+            "description": "Shared AI foundation for the ArtisanPack UI ecosystem, built on top of laravel/ai.",
+            "support": {
+                "issues": "https://github.com/ArtisanPack-UI/ai/issues",
+                "source": "https://github.com/ArtisanPack-UI/ai/tree/v1.0.0"
+            },
+            "time": "2026-07-06T21:25:38+00:00"
+        },
+        {
             "name": "artisanpack-ui/code-style",
             "version": "1.1.1",
             "source": {
@@ -6508,6 +6212,157 @@
                 "source": "https://github.com/ArtisanPack-UI/code-style-pint/tree/v1.1.1"
             },
             "time": "2026-06-09T00:58:49+00:00"
+        },
+        {
+            "name": "aws/aws-crt-php",
+            "version": "v1.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/awslabs/aws-crt-php.git",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/awslabs/aws-crt-php/zipball/d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35||^5.6.3||^9.5",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "suggest": {
+                "ext-awscrt": "Make sure you install awscrt native extension to use any of the functionality."
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "AWS SDK Common Runtime Team",
+                    "email": "aws-sdk-common-runtime@amazon.com"
+                }
+            ],
+            "description": "AWS Common Runtime for PHP",
+            "homepage": "https://github.com/awslabs/aws-crt-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "crt",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/awslabs/aws-crt-php/issues",
+                "source": "https://github.com/awslabs/aws-crt-php/tree/v1.2.7"
+            },
+            "time": "2024-10-18T22:15:13+00:00"
+        },
+        {
+            "name": "aws/aws-sdk-php",
+            "version": "3.387.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aws/aws-sdk-php.git",
+                "reference": "20818be961ace3ef01c1aed3c247e71b26020149"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/20818be961ace3ef01c1aed3c247e71b26020149",
+                "reference": "20818be961ace3ef01c1aed3c247e71b26020149",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-crt-php": "^1.2.3",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/promises": "^2.0",
+                "guzzlehttp/psr7": "^2.4.5",
+                "mtdowling/jmespath.php": "^2.9.1",
+                "php": ">=8.1",
+                "psr/http-message": "^1.0 || ^2.0",
+                "symfony/filesystem": "^v5.4.45 || ^v6.4.3 || ^v7.1.0 || ^v8.0.0"
+            },
+            "require-dev": {
+                "andrewsville/php-token-reflection": "^1.4",
+                "aws/aws-php-sns-message-validator": "~1.0",
+                "behat/behat": "~3.0",
+                "composer/composer": "^2.7.8",
+                "dms/phpunit-arraysubset-asserts": "^v0.5.0",
+                "doctrine/cache": "~1.4",
+                "ext-dom": "*",
+                "ext-openssl": "*",
+                "ext-sockets": "*",
+                "phpunit/phpunit": "^10.0",
+                "psr/cache": "^2.0 || ^3.0",
+                "psr/simple-cache": "^2.0 || ^3.0",
+                "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
+                "yoast/phpunit-polyfills": "^2.0"
+            },
+            "suggest": {
+                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
+                "doctrine/cache": "To use the DoctrineCacheAdapter",
+                "ext-curl": "To send requests using cURL",
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
+                "ext-pcntl": "To use client-side monitoring",
+                "ext-sockets": "To use client-side monitoring"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Aws\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/data/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Amazon Web Services",
+                    "homepage": "https://aws.amazon.com"
+                }
+            ],
+            "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
+            "homepage": "https://aws.amazon.com/sdk-for-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "cloud",
+                "dynamodb",
+                "ec2",
+                "glacier",
+                "s3",
+                "sdk"
+            ],
+            "support": {
+                "forum": "https://github.com/aws/aws-sdk-php/discussions",
+                "issues": "https://github.com/aws/aws-sdk-php/issues",
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.387.3"
+            },
+            "time": "2026-07-06T18:13:24+00:00"
         },
         {
             "name": "brianium/paratest",
@@ -7483,6 +7338,80 @@
             "time": "2025-03-19T14:43:43+00:00"
         },
         {
+            "name": "laravel/ai",
+            "version": "v0.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/ai.git",
+                "reference": "b23bc857576d7c4b3bb52ffd8be936ae74005d23"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/ai/zipball/b23bc857576d7c4b3bb52ffd8be936ae74005d23",
+                "reference": "b23bc857576d7c4b3bb52ffd8be936ae74005d23",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-sdk-php": "^3.339",
+                "illuminate/console": "^12.0|^13.0",
+                "illuminate/container": "^12.0|^13.0",
+                "illuminate/contracts": "^12.0|^13.0",
+                "illuminate/database": "^12.0|^13.0",
+                "illuminate/filesystem": "^12.0|^13.0",
+                "illuminate/json-schema": "^12.62|^13.15",
+                "illuminate/support": "^12.0|^13.0",
+                "laravel/prompts": "^0.3.6",
+                "laravel/serializable-closure": "^2.0",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "laravel/mcp": "^0.8",
+                "laravel/pint": "^1.26",
+                "mockery/mockery": "^1.6.12",
+                "orchestra/testbench": "^10.6|^11.0",
+                "pestphp/pest": "^3.0|^4.0",
+                "pestphp/pest-plugin-laravel": "^3.0|^4.0",
+                "phpstan/phpstan": "^2.1"
+            },
+            "suggest": {
+                "laravel/mcp": "Required to use MCP client tools or MCP server tools with Laravel AI agents."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Ai\\AiServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "functions.php"
+                ],
+                "psr-4": {
+                    "Laravel\\Ai\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The official AI SDK for Laravel.",
+            "homepage": "https://github.com/laravel/ai",
+            "keywords": [
+                "ai",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/ai/issues",
+                "source": "https://github.com/laravel/ai"
+            },
+            "time": "2026-06-10T11:23:35+00:00"
+        },
+        {
             "name": "laravel/pail",
             "version": "v1.2.7",
             "source": {
@@ -7854,6 +7783,72 @@
                 "source": "https://github.com/mockery/mockery"
             },
             "time": "2024-05-16T03:13:13+00:00"
+        },
+        {
+            "name": "mtdowling/jmespath.php",
+            "version": "2.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jmespath/jmespath.php.git",
+                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
+                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.17"
+            },
+            "require-dev": {
+                "composer/xdebug-handler": "^3.0.3",
+                "phpunit/phpunit": "^8.5.52"
+            },
+            "bin": [
+                "bin/jp.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.9-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/JmesPath.php"
+                ],
+                "psr-4": {
+                    "JmesPath\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Declaratively specify how to extract elements from a JSON document",
+            "keywords": [
+                "json",
+                "jsonpath"
+            ],
+            "support": {
+                "issues": "https://github.com/jmespath/jmespath.php/issues",
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.9.2"
+            },
+            "time": "2026-07-06T18:56:19+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -11404,6 +11399,77 @@
                 }
             ],
             "time": "2024-10-20T05:08:20+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/99aec13b82b4967ec5088222c4a3ecca955949c2",
+                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v8.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/options-resolver",

--- a/src/Services/MetaTagService.php
+++ b/src/Services/MetaTagService.php
@@ -21,8 +21,10 @@ use ArtisanPackUI\SEO\DTOs\MetaTagsDTO;
 use ArtisanPackUI\SEO\Models\SeoMeta;
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
+use function applyFilters;
 
 /**
  * MetaTagService class.
@@ -40,26 +42,42 @@ class MetaTagService
 	/**
 	 * Generate meta tags for a model.
 	 *
+	 * Fires the `ap.seo.metaTags` filter with the assembled tag array
+	 * so integrators can add, remove, or rewrite tags before rendering.
+	 * Filter payload: `(array $tags, ?Model $subject, Request $request)`.
+	 *
 	 * @since 1.0.0
 	 *
-	 * @param  Model          $model    The model to generate tags for.
-	 * @param  SeoMeta|null   $seoMeta  Optional SeoMeta instance.
+	 * @param  Model         $model    The model to generate tags for.
+	 * @param  SeoMeta|null  $seoMeta  Optional SeoMeta instance.
+	 * @param  Request|null  $request  Optional request; resolved from the container when null.
 	 *
 	 * @return MetaTagsDTO
 	 */
-	public function generate( Model $model, ?SeoMeta $seoMeta = null ): MetaTagsDTO
+	public function generate( Model $model, ?SeoMeta $seoMeta = null, ?Request $request = null ): MetaTagsDTO
 	{
-		$title       = $this->resolveTitle( $model, $seoMeta );
-		$description = $this->resolveDescription( $model, $seoMeta );
-		$canonical   = $this->resolveCanonical( $model, $seoMeta );
-		$robots      = $this->resolveRobots( $seoMeta );
+		$tags = [
+			'title'           => $this->resolveTitle( $model, $seoMeta ),
+			'description'     => $this->resolveDescription( $model, $seoMeta ),
+			'canonical'       => $this->resolveCanonical( $model, $seoMeta ),
+			'robots'          => $this->resolveRobots( $seoMeta ),
+			'additionalMeta'  => $this->getAdditionalMeta( $model, $seoMeta ),
+		];
+
+		$request = $request ?? app( 'request' );
+
+		$filtered = applyFilters( 'ap.seo.metaTags', $tags, $model, $request );
+
+		if ( ! is_array( $filtered ) ) {
+			$filtered = $tags;
+		}
 
 		return new MetaTagsDTO(
-			title: $title,
-			description: $description,
-			canonical: $canonical,
-			robots: $robots,
-			additionalMeta: $this->getAdditionalMeta( $model, $seoMeta ),
+			title: (string) ( $filtered['title'] ?? '' ),
+			description: $filtered['description'] ?? null,
+			canonical: (string) ( $filtered['canonical'] ?? '' ),
+			robots: (string) ( $filtered['robots'] ?? 'index, follow' ),
+			additionalMeta: (array) ( $filtered['additionalMeta'] ?? [] ),
 		);
 	}
 

--- a/src/Services/VisualEditorIntegration.php
+++ b/src/Services/VisualEditorIntegration.php
@@ -104,11 +104,7 @@ class VisualEditorIntegration
 			return;
 		}
 
-		if ( ! PackageDetector::hasHooks() ) {
-			return;
-		}
-
-		addFilter( 'visual_editor.pre_publish_checks', function ( Collection $checks, Model $page ) {
+		addFilter( 'ap.visualEditor.prePublishChecks', function ( Collection $checks, Model $page ) {
 			return $checks->merge( $this->getSeoChecks( $page ) );
 		} );
 	}

--- a/src/Sitemap/Generators/SitemapGenerator.php
+++ b/src/Sitemap/Generators/SitemapGenerator.php
@@ -22,6 +22,7 @@ use ArtisanPackUI\SEO\Models\SitemapEntry;
 use DateTimeInterface;
 use Illuminate\Support\Collection;
 use XMLWriter;
+use function applyFilters;
 
 /**
  * SitemapGenerator class.
@@ -78,6 +79,7 @@ class SitemapGenerator
 	public function generate( ?string $type = null, int $page = 1 ): string
 	{
 		$entries = $this->getEntries( $type, $page );
+		$entries = $this->applyEntriesFilter( $entries, $type ?? '' );
 
 		return $this->buildXml( $entries );
 	}
@@ -97,7 +99,9 @@ class SitemapGenerator
 
 		$entries = $urls->map( function ( $url ) use ( $provider ) {
 			return $this->normalizeProviderUrl( $url, $provider );
-		} )->filter();
+		} )->filter()->values();
+
+		$entries = $this->applyEntriesFilter( $entries, $provider->getType() );
 
 		return $this->buildXml( $entries );
 	}
@@ -134,6 +138,29 @@ class SitemapGenerator
 	public function getMaxUrls(): int
 	{
 		return $this->maxUrls;
+	}
+
+	/**
+	 * Apply the `ap.seo.sitemapEntries` filter to a collection of entries.
+	 *
+	 * Converts the collection to an array so filter callbacks can freely
+	 * add, remove, or reorder entries, then wraps the result back into a
+	 * collection for XML rendering.
+	 *
+	 * Filter payload: `(array $entries, string $sitemapType)`.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  Collection  $entries      The entries prior to filtering.
+	 * @param  string      $sitemapType  The sitemap type identifier.
+	 *
+	 * @return Collection
+	 */
+	protected function applyEntriesFilter( Collection $entries, string $sitemapType ): Collection
+	{
+		$filtered = applyFilters( 'ap.seo.sitemapEntries', $entries->all(), $sitemapType );
+
+		return collect( is_array( $filtered ) ? $filtered : $entries->all() );
 	}
 
 	/**

--- a/src/Support/PackageDetector.php
+++ b/src/Support/PackageDetector.php
@@ -42,18 +42,6 @@ class PackageDetector
 	}
 
 	/**
-	 * Check if the hooks package is installed.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return bool True if hooks package is available.
-	 */
-	public static function hasHooks(): bool
-	{
-		return function_exists( 'addFilter' ) || function_exists( 'applyFilters' );
-	}
-
-	/**
 	 * Check if the accessibility package is installed.
 	 *
 	 * @since 1.0.0

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ declare( strict_types=1 );
 namespace Tests;
 
 use ArtisanPackUI\Ai\AiServiceProvider;
+use ArtisanPackUI\Hooks\Providers\HooksServiceProvider;
 use ArtisanPackUI\SEO\Providers\SEOServiceProvider;
 use Illuminate\Support\Facades\Blade;
 use Livewire\LivewireServiceProvider;
@@ -89,7 +90,7 @@ abstract class TestCase extends BaseTestCase
      */
     protected function getPackageProviders( $app ): array
     {
-        $providers = [ LivewireServiceProvider::class ];
+        $providers = [ LivewireServiceProvider::class, HooksServiceProvider::class ];
 
         // AI provider is optional — only register when artisanpack-ui/ai is installed.
         if ( class_exists( AiServiceProvider::class ) ) {

--- a/tests/Unit/Services/MetaTagServiceHooksTest.php
+++ b/tests/Unit/Services/MetaTagServiceHooksTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * MetaTagService Hook Tests.
+ *
+ * Tests the `ap.seo.metaTags` filter hook fired during meta tag assembly.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Hooks\Facades\Filter;
+use ArtisanPackUI\SEO\DTOs\MetaTagsDTO;
+use ArtisanPackUI\SEO\Services\MetaTagService;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
+
+beforeEach( function (): void {
+	config( [
+		'seo.site.name'                       => 'Test Site',
+		'seo.site.separator'                  => ' | ',
+		'seo.defaults.robots'                 => 'index, follow',
+		'seo.defaults.description_max_length' => 160,
+		'app.name'                            => 'Laravel',
+	] );
+
+	Filter::removeAll( 'ap.seo.metaTags' );
+} );
+
+afterEach( function (): void {
+	Filter::removeAll( 'ap.seo.metaTags' );
+} );
+
+function makeHookTestModel( array $attributes = [] ): Model
+{
+	return new class( $attributes ) extends Model {
+		protected $guarded = [];
+
+		public function __construct( array $attributes = [] )
+		{
+			parent::__construct();
+			foreach ( $attributes as $key => $value ) {
+				$this->setAttribute( $key, $value );
+			}
+		}
+	};
+}
+
+describe( 'MetaTagService ap.seo.metaTags filter', function (): void {
+
+	it( 'fires the ap.seo.metaTags filter with tags, subject, and request', function (): void {
+		$service = new MetaTagService();
+		$model   = makeHookTestModel( [ 'title' => 'Original Title' ] );
+		$request = Request::create( '/example' );
+
+		$captured = [];
+
+		addFilter( 'ap.seo.metaTags', function ( array $tags, ?Model $subject, Request $req ) use ( &$captured ): array {
+			$captured['tags']    = $tags;
+			$captured['subject'] = $subject;
+			$captured['request'] = $req;
+
+			return $tags;
+		} );
+
+		$service->generate( $model, null, $request );
+
+		expect( $captured )->toHaveKey( 'tags' )
+			->and( $captured['tags'] )->toBeArray()
+			->and( $captured['tags'] )->toHaveKeys( [ 'title', 'description', 'canonical', 'robots', 'additionalMeta' ] )
+			->and( $captured['subject'] )->toBe( $model )
+			->and( $captured['request'] )->toBe( $request );
+	} );
+
+	it( 'allows the filter to rewrite tags before the DTO is built', function (): void {
+		$service = new MetaTagService();
+		$model   = makeHookTestModel( [ 'title' => 'Original Title' ] );
+
+		addFilter( 'ap.seo.metaTags', function ( array $tags ): array {
+			$tags['title']       = 'Filtered Title';
+			$tags['description'] = 'Filtered description';
+			$tags['robots']      = 'noindex, nofollow';
+
+			return $tags;
+		} );
+
+		$dto = $service->generate( $model );
+
+		expect( $dto )->toBeInstanceOf( MetaTagsDTO::class )
+			->and( $dto->title )->toBe( 'Filtered Title' )
+			->and( $dto->description )->toBe( 'Filtered description' )
+			->and( $dto->robots )->toBe( 'noindex, nofollow' );
+	} );
+
+	it( 'falls back to the unfiltered tags when a callback returns a non-array', function (): void {
+		$service = new MetaTagService();
+		$model   = makeHookTestModel( [ 'title' => 'Original Title' ] );
+
+		addFilter( 'ap.seo.metaTags', function (): ?array {
+			return null;
+		} );
+
+		$dto = $service->generate( $model );
+
+		expect( $dto )->toBeInstanceOf( MetaTagsDTO::class )
+			->and( $dto->title )->toContain( 'Original Title' )
+			->and( $dto->robots )->toBe( 'index, follow' );
+	} );
+
+	it( 'resolves the current request when no request is provided', function (): void {
+		$service = new MetaTagService();
+		$model   = makeHookTestModel();
+
+		$seen = null;
+
+		addFilter( 'ap.seo.metaTags', function ( array $tags, ?Model $subject, Request $req ) use ( &$seen ): array {
+			$seen = $req;
+
+			return $tags;
+		} );
+
+		$service->generate( $model );
+
+		expect( $seen )->toBeInstanceOf( Request::class );
+	} );
+
+} );

--- a/tests/Unit/Services/SitemapServiceTest.php
+++ b/tests/Unit/Services/SitemapServiceTest.php
@@ -215,6 +215,7 @@ describe( 'SitemapService', function (): void {
 		] ) );
 		$provider->shouldReceive( 'getChangeFrequency' )->andReturn( 'weekly' );
 		$provider->shouldReceive( 'getPriority' )->andReturn( 0.5 );
+		$provider->shouldReceive( 'getType' )->andReturn( 'custom' );
 
 		$service = new SitemapService();
 		$service->registerProvider( 'custom', $provider );

--- a/tests/Unit/Services/VisualEditorIntegrationHookTest.php
+++ b/tests/Unit/Services/VisualEditorIntegrationHookTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * VisualEditorIntegration Hook Tests.
+ *
+ * Verifies the SEO integration subscribes to the renamed
+ * `ap.visualEditor.prePublishChecks` filter hook.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Hooks\Facades\Filter;
+use ArtisanPackUI\SEO\Services\AnalysisService;
+use ArtisanPackUI\SEO\Services\VisualEditorIntegration;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
+
+uses( RefreshDatabase::class );
+
+beforeEach( function (): void {
+	$this->artisan( 'migrate', [ '--path' => realpath( __DIR__ . '/../../../database/migrations' ) ] );
+
+	Filter::removeAll( 'ap.visualEditor.prePublishChecks' );
+	Filter::removeAll( 'visual_editor.pre_publish_checks' );
+} );
+
+afterEach( function (): void {
+	Filter::removeAll( 'ap.visualEditor.prePublishChecks' );
+	Filter::removeAll( 'visual_editor.pre_publish_checks' );
+} );
+
+function makeVeHookPage(): Model
+{
+	return new class extends Model {
+		protected $guarded = [];
+	};
+}
+
+describe( 'VisualEditorIntegration hook subscriber', function (): void {
+
+	it( 'subscribes to ap.visualEditor.prePublishChecks and appends SEO checks', function (): void {
+		$integration = Mockery::mock( VisualEditorIntegration::class, [ new AnalysisService() ] )->makePartial();
+		$integration->shouldReceive( 'isAvailable' )->andReturn( true );
+		$integration->shouldReceive( 'getSeoChecks' )->andReturn( collect( [
+			[ 'type' => 'warning', 'message' => 'Test check', 'suggestion' => '' ],
+		] ) );
+
+		$integration->registerPrePublishChecks();
+
+		$result = applyFilters(
+			'ap.visualEditor.prePublishChecks',
+			collect( [ [ 'type' => 'info', 'message' => 'Existing', 'suggestion' => '' ] ] ),
+			makeVeHookPage(),
+		);
+
+		expect( $result )->toBeInstanceOf( Collection::class )
+			->and( $result->count() )->toBe( 2 )
+			->and( $result->pluck( 'message' )->all() )->toContain( 'Existing', 'Test check' );
+	} );
+
+	it( 'does not subscribe to the deprecated visual_editor.pre_publish_checks hook name', function (): void {
+		$integration = Mockery::mock( VisualEditorIntegration::class, [ new AnalysisService() ] )->makePartial();
+		$integration->shouldReceive( 'isAvailable' )->andReturn( true );
+		$integration->shouldNotReceive( 'getSeoChecks' );
+
+		$integration->registerPrePublishChecks();
+
+		$initial = collect( [ [ 'type' => 'info', 'message' => 'Existing', 'suggestion' => '' ] ] );
+		$result  = applyFilters( 'visual_editor.pre_publish_checks', $initial, makeVeHookPage() );
+
+		expect( $result )->toBe( $initial );
+	} );
+
+} );

--- a/tests/Unit/Sitemap/SitemapGeneratorHooksTest.php
+++ b/tests/Unit/Sitemap/SitemapGeneratorHooksTest.php
@@ -1,0 +1,153 @@
+<?php
+
+/**
+ * SitemapGenerator Hook Tests.
+ *
+ * Tests the `ap.seo.sitemapEntries` filter hook fired during sitemap generation.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SEO
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Hooks\Facades\Filter;
+use ArtisanPackUI\SEO\Contracts\SitemapProviderContract;
+use ArtisanPackUI\SEO\Models\SitemapEntry;
+use ArtisanPackUI\SEO\Sitemap\Generators\SitemapGenerator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
+
+uses( RefreshDatabase::class );
+
+beforeEach( function (): void {
+	$this->artisan( 'migrate', [ '--path' => realpath( __DIR__ . '/../../../database/migrations' ) ] );
+
+	Filter::removeAll( 'ap.seo.sitemapEntries' );
+} );
+
+afterEach( function (): void {
+	Filter::removeAll( 'ap.seo.sitemapEntries' );
+} );
+
+describe( 'SitemapGenerator ap.seo.sitemapEntries filter', function (): void {
+
+	it( 'fires the filter with the entries array and sitemap type', function (): void {
+		SitemapEntry::create( [
+			'sitemapable_type' => 'App\\Models\\Page',
+			'sitemapable_id'   => 1,
+			'url'              => 'https://example.com/page-1',
+			'type'             => 'page',
+		] );
+
+		$captured = [];
+
+		addFilter( 'ap.seo.sitemapEntries', function ( array $entries, string $sitemapType ) use ( &$captured ): array {
+			$captured['entries'] = $entries;
+			$captured['type']    = $sitemapType;
+
+			return $entries;
+		} );
+
+		( new SitemapGenerator() )->generate( 'page' );
+
+		expect( $captured )->toHaveKeys( [ 'entries', 'type' ] )
+			->and( $captured['entries'] )->toBeArray()
+			->and( $captured['entries'] )->toHaveCount( 1 )
+			->and( $captured['type'] )->toBe( 'page' );
+	} );
+
+	it( 'allows callbacks to append new entries', function (): void {
+		SitemapEntry::create( [
+			'sitemapable_type' => 'App\\Models\\Page',
+			'sitemapable_id'   => 1,
+			'url'              => 'https://example.com/page-1',
+			'type'             => 'page',
+		] );
+
+		addFilter( 'ap.seo.sitemapEntries', function ( array $entries ): array {
+			$entries[] = [
+				'url'        => 'https://example.com/injected',
+				'lastmod'    => null,
+				'changefreq' => 'weekly',
+				'priority'   => 0.5,
+			];
+
+			return $entries;
+		} );
+
+		$xml = ( new SitemapGenerator() )->generate();
+
+		expect( $xml )->toContain( 'https://example.com/page-1' )
+			->and( $xml )->toContain( 'https://example.com/injected' );
+	} );
+
+	it( 'allows callbacks to remove entries', function (): void {
+		SitemapEntry::create( [
+			'sitemapable_type' => 'App\\Models\\Page',
+			'sitemapable_id'   => 1,
+			'url'              => 'https://example.com/keep',
+			'type'             => 'page',
+		] );
+		SitemapEntry::create( [
+			'sitemapable_type' => 'App\\Models\\Page',
+			'sitemapable_id'   => 2,
+			'url'              => 'https://example.com/drop',
+			'type'             => 'page',
+		] );
+
+		addFilter( 'ap.seo.sitemapEntries', function ( array $entries ): array {
+			return array_values( array_filter( $entries, function ( $entry ): bool {
+				$url = $entry instanceof SitemapEntry ? $entry->url : ( $entry['url'] ?? '' );
+
+				return ! str_contains( $url, '/drop' );
+			} ) );
+		} );
+
+		$xml = ( new SitemapGenerator() )->generate();
+
+		expect( $xml )->toContain( 'https://example.com/keep' )
+			->and( $xml )->not->toContain( 'https://example.com/drop' );
+	} );
+
+	it( 'fires the filter with the provider type when generating from a provider', function (): void {
+		$captured = [];
+
+		addFilter( 'ap.seo.sitemapEntries', function ( array $entries, string $sitemapType ) use ( &$captured ): array {
+			$captured[] = $sitemapType;
+
+			return $entries;
+		} );
+
+		$provider = new class implements SitemapProviderContract {
+			public function getUrls(): Collection
+			{
+				return collect( [
+					[ 'loc' => 'https://example.com/custom' ],
+				] );
+			}
+
+			public function getChangeFrequency(): string
+			{
+				return 'weekly';
+			}
+
+			public function getPriority(): float
+			{
+				return 0.7;
+			}
+
+			public function getType(): string
+			{
+				return 'custom-provider';
+			}
+		};
+
+		( new SitemapGenerator() )->generateFromProvider( $provider );
+
+		expect( $captured )->toContain( 'custom-provider' );
+	} );
+
+} );

--- a/tests/Unit/Sitemap/SitemapGeneratorTest.php
+++ b/tests/Unit/Sitemap/SitemapGeneratorTest.php
@@ -168,6 +168,7 @@ describe( 'SitemapGenerator', function (): void {
 		] ) );
 		$provider->shouldReceive( 'getChangeFrequency' )->andReturn( 'weekly' );
 		$provider->shouldReceive( 'getPriority' )->andReturn( 0.5 );
+		$provider->shouldReceive( 'getType' )->andReturn( 'custom' );
 
 		$generator = new SitemapGenerator();
 		$xml       = $generator->generateFromProvider( $provider );

--- a/tests/Unit/Support/PackageDetectorTest.php
+++ b/tests/Unit/Support/PackageDetectorTest.php
@@ -32,23 +32,6 @@ describe( 'PackageDetector hasMediaLibrary', function (): void {
 
 } );
 
-describe( 'PackageDetector hasHooks', function (): void {
-
-	it( 'returns boolean value', function (): void {
-		$result = PackageDetector::hasHooks();
-
-		expect( $result )->toBeBool();
-	} );
-
-	it( 'returns consistent results', function (): void {
-		$result1 = PackageDetector::hasHooks();
-		$result2 = PackageDetector::hasHooks();
-
-		expect( $result1 )->toBe( $result2 );
-	} );
-
-} );
-
 describe( 'PackageDetector hasAccessibility', function (): void {
 
 	it( 'returns boolean value', function (): void {


### PR DESCRIPTION
## Description

Adds two new filter hooks to the SEO package and renames the visual-editor subscriber to match the Wave 3 hook rename. Promotes `artisanpack-ui/hooks` from an optional gated dependency to a required `^1.3` dependency.

**Closes:** #62

## Type of Change

- [x] New feature (adds new functionality)
- [x] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** #62

## Motivation and Context

Wave 5 of the cross-package hooks standardization initiative. The SEO package needed to (1) fire two new filter hooks so integrators can extend meta tag assembly and sitemap generation, and (2) update its VE pre-publish subscriber to the renamed `ap.visualEditor.prePublishChecks` hook name (fired by visual-editor in Wave 3).

## Changes Made

- Added `ap.seo.metaTags` filter fired in `MetaTagService::generate()` with payload `(array $tags, ?Model $subject, Request $request)`.
- Added `ap.seo.sitemapEntries` filter fired in `SitemapGenerator::generate()` and `generateFromProvider()` with payload `(array $entries, string $sitemapType)`.
- Both filter sites fall back to the unfiltered value if a callback returns a non-array.
- Renamed VE subscriber from `visual_editor.pre_publish_checks` → `ap.visualEditor.prePublishChecks`.
- Promoted `artisanpack-ui/hooks: ^1.3` to a required dependency; removed the `PackageDetector::hasHooks()` gate and the method itself.
- Added `HooksServiceProvider` to the test base class.
- Updated two existing sitemap provider mocks to satisfy the new `getType()` call.
- CHANGELOG + README updated for 1.3.0; version bumped in `composer.json`.

## How Has This Been Tested?

**Testing Environment:**
- PHP Version: 8.4.3
- Project Version: 1.3.0

**Tests Performed:**
1. Full pest suite (1362 passing, 3195 assertions).
2. New `MetaTagServiceHooksTest` covers the metaTags filter payload, tag rewriting, request resolution, and non-array fallback.
3. New `SitemapGeneratorHooksTest` covers the sitemapEntries filter for DB entries and custom providers, including append/remove.
4. New `VisualEditorIntegrationHookTest` verifies the new hook name is subscribed and the old name is not.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:** 3 new test files (9 test cases) plus a regression test for the non-array fallback. Full suite: 1362 passed.

## Documentation

- [x] Inline code documentation added
- [x] README updated

**Documentation details:** README now includes a hook table + updated callback examples using the new `ap.*` naming. CHANGELOG entry added for 1.3.0.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code has been linted
- [x] Code follows project style guide
- [x] Self-review completed
- [x] No new warnings generated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SEO filter hooks for customizing meta tags and sitemap entries.
  * Added support for extending Visual Editor pre-publish SEO checks.
* **Documentation**
  * Updated filter hook documentation with usage examples and payload details.
  * Added release notes for version 1.3.0.
* **Bug Fixes**
  * Preserved default SEO metadata and sitemap output when filters return invalid results.
* **Chores**
  * Updated the package to version 1.3.0 and enabled the required hooks integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->